### PR TITLE
Add `Playground` page for Lightpanda Cloud

### DIFF
--- a/src/content/run-on-lightpanda-cloud/_meta.ts
+++ b/src/content/run-on-lightpanda-cloud/_meta.ts
@@ -2,6 +2,7 @@ import type { MetaRecord } from 'nextra'
 
 const meta: MetaRecord = {
   'getting-started': 'Getting started',
+  playground: 'Playground',
   'limits-and-billing': 'Limits and billing',
 }
 

--- a/src/content/run-on-lightpanda-cloud/getting-started.mdx
+++ b/src/content/run-on-lightpanda-cloud/getting-started.mdx
@@ -27,8 +27,6 @@ Connect to the region nearest your script. The snippets below all use `euwest`:
 - `wss://euwest.cloud.lightpanda.io/ws` (west Europe)
 - `wss://uswest.cloud.lightpanda.io/ws` (west US)
 
-Prefer not to run it locally either? The [playground](/run-on-lightpanda-cloud/playground) keeps the script in the console and runs it there against a cloud browser.
-
 <Tabs items={['CDP URL', 'Puppeteer', 'Playwright', 'Chromedp']}>
   <Tabs.Tab>
 The raw endpoint every CDP client connects to:
@@ -103,9 +101,10 @@ The cloud serves Lightpanda by default. For debugging, append `browser=chrome` t
 
 The same URL takes a `proxy` parameter to route the session through a shared proxy, or through one you added on the [proxies page](https://console.lightpanda.io/proxies) in the console.
 
-## Other features: HTTP API and MCP
+## Other features: playground, HTTP API and MCP
 
 The cloud also exposes:
 
+- a **[playground](/run-on-lightpanda-cloud/playground)** to write and run a script from the console, with no local setup at all.
 - an **[HTTP API](/usage/api)** to fetch a page's HTML or Markdown in a single request, with no CDP script.
 - an **[MCP](/usage/mcp)** server to drive the browser from AI applications over the Model Context Protocol.

--- a/src/content/run-on-lightpanda-cloud/getting-started.mdx
+++ b/src/content/run-on-lightpanda-cloud/getting-started.mdx
@@ -27,6 +27,8 @@ Connect to the region nearest your script. The snippets below all use `euwest`:
 - `wss://euwest.cloud.lightpanda.io/ws` (west Europe)
 - `wss://uswest.cloud.lightpanda.io/ws` (west US)
 
+Prefer not to run it locally either? The [playground](/run-on-lightpanda-cloud/playground) keeps the script in the console and runs it there against a cloud browser.
+
 <Tabs items={['CDP URL', 'Puppeteer', 'Playwright', 'Chromedp']}>
   <Tabs.Tab>
 The raw endpoint every CDP client connects to:

--- a/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
+++ b/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
@@ -27,7 +27,7 @@ Upgrade, download invoices, or cancel from the [billing page](https://console.li
 
 **Concurrent sessions** are the sessions open at one instant. This limit is about parallelism, not total volume: a plan's concurrency cap still lets you run many sessions a day, as long as no more than that cap overlap at once.
 
-Sessions opened from the [playground](/run-on-lightpanda-cloud/playground) are ordinary sessions, so they count toward both limits.
+Both apply however you open the session: over CDP, MCP, the HTTP API, or from the playground.
 
 ## When you reach a limit
 

--- a/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
+++ b/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
@@ -27,7 +27,7 @@ Upgrade, download invoices, or cancel from the [billing page](https://console.li
 
 **Concurrent sessions** are the sessions open at one instant. This limit is about parallelism, not total volume: a plan's concurrency cap still lets you run many sessions a day, as long as no more than that cap overlap at once.
 
-Both apply however you open the session: over CDP, MCP, the HTTP API, or from the playground.
+Both limits apply regardless of how you open a session: over CDP, MCP, the HTTP API, or from the playground.
 
 ## When you reach a limit
 

--- a/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
+++ b/src/content/run-on-lightpanda-cloud/limits-and-billing.mdx
@@ -27,6 +27,8 @@ Upgrade, download invoices, or cancel from the [billing page](https://console.li
 
 **Concurrent sessions** are the sessions open at one instant. This limit is about parallelism, not total volume: a plan's concurrency cap still lets you run many sessions a day, as long as no more than that cap overlap at once.
 
+Sessions opened from the [playground](/run-on-lightpanda-cloud/playground) are ordinary sessions, so they count toward both limits.
+
 ## When you reach a limit
 
 If you open more sessions than your concurrency limit allows, the extra sessions are rejected with HTTP `429 Too Many Requests`. Retry once a running session ends, or upgrade for more concurrency.

--- a/src/content/run-on-lightpanda-cloud/playground.mdx
+++ b/src/content/run-on-lightpanda-cloud/playground.mdx
@@ -1,0 +1,109 @@
+---
+title: Playground
+description: Write and run browser automation scripts from the Lightpanda Cloud console, with Puppeteer and Playwright preinstalled and no local setup.
+---
+
+import { Tabs, Callout } from 'nextra/components'
+
+# Playground
+
+The playground is a code editor in the console that runs your automation scripts on Lightpanda Cloud. You write JavaScript or TypeScript, pick the browser and region to run against, and read the output on the same screen. Nothing runs on your machine.
+
+## Write and run a script
+
+Open [Scripts](https://console.lightpanda.io/playground/scripts) under Playground in the console and create one. The editor opens on the Playwright example below. Both clients reach your cloud browser through `CDP_WS_URL`, and both examples work unchanged in either language:
+
+<Tabs items={['Playwright', 'Puppeteer']}>
+  <Tabs.Tab>
+```js copy
+import { chromium } from 'playwright-core';
+
+// Connect Playwright's chromium driver to the browser.
+const browser = await chromium.connectOverCDP(process.env.CDP_WS_URL);
+
+const context = await browser.newContext({});
+const page = await context.newPage();
+
+await page.goto('https://wikipedia.com/');
+
+const title = await page.locator('h1').textContent();
+console.log(title);
+
+await page.close();
+await context.close();
+await browser.close();
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```js copy
+import puppeteer from 'puppeteer-core';
+
+// Connect Puppeteer to the browser.
+const browser = await puppeteer.connect({
+  browserWSEndpoint: process.env.CDP_WS_URL,
+});
+
+const context = await browser.createBrowserContext();
+const page = await context.newPage();
+
+await page.goto('https://wikipedia.com/');
+
+const title = await page.$eval('h1', el => el.textContent);
+console.log(title);
+
+await page.close();
+await context.close();
+await browser.disconnect();
+```
+  </Tabs.Tab>
+</Tabs>
+
+Name the script, set the language to JavaScript or TypeScript in the Settings panel, then select Run script. The Output tab fills in as the run proceeds, with anything your script writes to stderr shown in red. Edits are saved as you type, so a script you leave is there when you come back.
+
+## Connect with CDP_WS_URL
+
+Your script never carries a token. The playground sets one environment variable, `CDP_WS_URL`, which holds the WebSocket address your client uses to reach the browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP). The playground assembles it from the choices in the Default variables panel:
+
+| Variable | Values | What it controls |
+| --- | --- | --- |
+| Region | `euwest`, `uswest` | Which region serves the browser |
+| Token | one of your active tokens | Which token the run authenticates with |
+| Browser | `lightpanda`, `chrome` | Which browser runs. Chrome is for debugging, not production traffic |
+| Proxy | one of your proxies, or none | The outbound IP the browser uses |
+
+Pass `process.env.CDP_WS_URL` to whichever client you use. With Playwright that is `chromium.connectOverCDP`, and with Puppeteer it is the `browserWSEndpoint` option.
+
+<Callout type="info">
+`console.log(process.env.CDP_WS_URL)` prints `***`, not the URL. The URL carries an access token created for the run, and run output is stored in the console, so the playground masks the URL wherever it appears in output.
+</Callout>
+
+## What the runtime provides
+
+Scripts run in an isolated container. Both CDP clients are preinstalled at fixed versions, so there is no install step:
+
+| Package | Version |
+| --- | --- |
+| `playwright-core` | 1.50.0 |
+| `puppeteer-core` | 24.0.0 |
+
+The rest of the environment is fixed too:
+
+- **Language.** JavaScript and TypeScript both run through [tsx](https://tsx.is/), so `import` syntax and top-level `await` work in either without configuration.
+- **Packages.** You cannot install anything beyond the two clients above.
+- **Filesystem.** Read-only, apart from a writable `/tmp`.
+
+Every run is capped:
+
+| Limit | Value |
+| --- | --- |
+| Run time | 5 minutes |
+| Memory | 256 MB |
+| CPU | 1 core |
+| Output captured | 256 KB |
+| Processes | 64 |
+
+A run that reaches 5 minutes stops and reports `timeout running program`. Output beyond 256 KB is dropped, and the run is flagged as truncated.
+
+## Review past runs
+
+Every run is kept. [Runs](https://console.lightpanda.io/playground/script-runs) under Playground lists them with their state, start time, and duration, and you can filter the list by script. Open a run to read the output it produced.

--- a/src/content/run-on-lightpanda-cloud/playground.mdx
+++ b/src/content/run-on-lightpanda-cloud/playground.mdx
@@ -104,6 +104,8 @@ Every run is capped:
 
 A run that reaches 5 minutes stops and reports `timeout running program`. Output beyond 256 KB is dropped, and the run is flagged as truncated.
 
+These caps apply to the script process. The browser it drives is an ordinary cloud session, so it also counts toward your [plan limits](/run-on-lightpanda-cloud/limits-and-billing).
+
 ## Review past runs
 
 Every run is kept. [Runs](https://console.lightpanda.io/playground/script-runs) under Playground lists them with their state, start time, and duration, and you can filter the list by script. Open a run to read the output it produced.

--- a/src/content/run-on-lightpanda-cloud/playground.mdx
+++ b/src/content/run-on-lightpanda-cloud/playground.mdx
@@ -7,11 +7,11 @@ import { Tabs, Callout } from 'nextra/components'
 
 # Playground
 
-The playground is a code editor in the console that runs your automation scripts on Lightpanda Cloud.
+The playground is a [code editor](https://console.lightpanda.io/playground/scripts) in the console that runs your automation scripts on Lightpanda Cloud.
 
 ## Write and run a script
 
-Open [Scripts](https://console.lightpanda.io/playground/scripts) under Playground in the console and create one. The editor opens on the Playwright example below:
+Your script reaches the browser through `CDP_WS_URL`, an environment variable the playground sets for you:
 
 <Tabs items={['Playwright', 'Puppeteer']}>
   <Tabs.Tab>
@@ -58,9 +58,9 @@ await browser.disconnect();
   </Tabs.Tab>
 </Tabs>
 
-## Connect with CDP_WS_URL
+## What CDP_WS_URL contains
 
-Your script never carries a token. The playground sets one environment variable, `CDP_WS_URL`, which holds the WebSocket address your client uses to reach the browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP). The playground assembles it from the choices in the Default variables panel:
+You do not need to hard-code a token in your script. `CDP_WS_URL` holds the WebSocket address your client uses to reach the browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP), assembled from the choices in the Default variables panel:
 
 | Default variable | Values | What it controls |
 | --- | --- | --- |
@@ -102,8 +102,6 @@ Every run is capped:
 
 A run that reaches 5 minutes stops and reports `timeout running program`. Output beyond 256 KB is dropped, and the run is flagged as truncated.
 
-These caps apply to the script process. The browser it drives is an ordinary cloud session, so it also counts toward your [plan limits](/run-on-lightpanda-cloud/limits-and-billing).
+These caps apply to the script process. The browser session driven by the script also counts toward your [plan limits](/run-on-lightpanda-cloud/limits-and-billing).
 
-## Review past runs
-
-Every run is kept. [Runs](https://console.lightpanda.io/playground/script-runs) under Playground lists them with their state, start time, and duration, and you can filter the list by script. Open a run to read the output it produced.
+The [Runs page](https://console.lightpanda.io/playground/script-runs) shows your run history and output for the past 30 days.

--- a/src/content/run-on-lightpanda-cloud/playground.mdx
+++ b/src/content/run-on-lightpanda-cloud/playground.mdx
@@ -7,11 +7,11 @@ import { Tabs, Callout } from 'nextra/components'
 
 # Playground
 
-The playground is a code editor in the console that runs your automation scripts on Lightpanda Cloud. You write JavaScript or TypeScript, pick the browser and region to run against, and read the output on the same screen. Nothing runs on your machine.
+The playground is a code editor in the console that runs your automation scripts on Lightpanda Cloud.
 
 ## Write and run a script
 
-Open [Scripts](https://console.lightpanda.io/playground/scripts) under Playground in the console and create one. The editor opens on the Playwright example below. Both clients reach your cloud browser through `CDP_WS_URL`, and both examples work unchanged in either language:
+Open [Scripts](https://console.lightpanda.io/playground/scripts) under Playground in the console and create one. The editor opens on the Playwright example below:
 
 <Tabs items={['Playwright', 'Puppeteer']}>
   <Tabs.Tab>
@@ -58,20 +58,18 @@ await browser.disconnect();
   </Tabs.Tab>
 </Tabs>
 
-Name the script, set the language to JavaScript or TypeScript in the Settings panel, then select Run script. The Output tab fills in as the run proceeds, with anything your script writes to stderr shown in red. Edits are saved as you type, so a script you leave is there when you come back.
-
 ## Connect with CDP_WS_URL
 
 Your script never carries a token. The playground sets one environment variable, `CDP_WS_URL`, which holds the WebSocket address your client uses to reach the browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP). The playground assembles it from the choices in the Default variables panel:
 
-| Variable | Values | What it controls |
+| Default variable | Values | What it controls |
 | --- | --- | --- |
 | Region | `euwest`, `uswest` | Which region serves the browser |
 | Token | one of your active tokens | Which token the run authenticates with |
 | Browser | `lightpanda`, `chrome` | Which browser runs. Chrome is for debugging, not production traffic |
 | Proxy | one of your proxies, or none | The outbound IP the browser uses |
 
-Pass `process.env.CDP_WS_URL` to whichever client you use. With Playwright that is `chromium.connectOverCDP`, and with Puppeteer it is the `browserWSEndpoint` option.
+Pass `process.env.CDP_WS_URL` to whichever client you use.
 
 <Callout type="info">
 `console.log(process.env.CDP_WS_URL)` prints `***`, not the URL. The URL carries an access token created for the run, and run output is stored in the console, so the playground masks the URL wherever it appears in output.

--- a/src/content/usage/cdp/playwright.mdx
+++ b/src/content/usage/cdp/playwright.mdx
@@ -61,6 +61,8 @@ await context.close();
 await browser.close();
 ```
 
+In the [playground](/run-on-lightpanda-cloud/playground), the console builds this URL for you and exposes it as `CDP_WS_URL`. Pass `process.env.CDP_WS_URL` to `connectOverCDP` there, since `LPD_TOKEN` does not exist in that runtime.
+
 ## Cloud options
 
 ### Endpoints

--- a/src/content/usage/cdp/puppeteer.mdx
+++ b/src/content/usage/cdp/puppeteer.mdx
@@ -67,6 +67,7 @@ await context.close()
 await browser.disconnect()
 ```
 
+In the [playground](/run-on-lightpanda-cloud/playground), the console builds this URL for you and exposes it as `CDP_WS_URL`. Pass `process.env.CDP_WS_URL` to `browserWSEndpoint` there, since `LPD_TOKEN` does not exist in that runtime.
 
 ## Cloud options
 


### PR DESCRIPTION
- Add a new **Playground** page documenting the console script editor, the `CDP_WS_URL` connection variable, the preinstalled CDP clients, and the run limits
- Link to it from **Getting started**, where it sits alongside the HTTP API and MCP as another way to use the cloud
- Note on **Puppeteer** and **Playwright** that the playground exposes `CDP_WS_URL` instead of `LPD_TOKEN`
- State on **Limits and billing** that browser hours and concurrency apply to every session, however it was opened

> [!NOTE]
> This branch is stacked on [#75](https://github.com/lightpanda-io/docs/pull/75) (`complete-cloud-section`), which is not merged yet. The base of this PR is [`complete-cloud-section`](https://github.com/lightpanda-io/docs/tree/complete-cloud-section) rather than `main`, so the diff shows only the playground commits. It needs to be retargeted to `main` once #75 lands, which GitHub does automatically if the `complete-cloud-section` branch is deleted on merge.

**Preview.** The marketing site pins `apps/docs` as a submodule, so each PR gets its own preview branch there:

| Branch on the site | Points at | Shows |
| --- | --- | --- |
| [`docs-playground`](https://github.com/lightpanda-io/lightpanda-io.github.io/tree/docs-playground) | [`playground`](https://github.com/lightpanda-io/docs/tree/playground) | this PR, on top of #75 |
| [`complete-cloud-section`](https://github.com/lightpanda-io/lightpanda-io.github.io/tree/complete-cloud-section) | [`complete-cloud-section`](https://github.com/lightpanda-io/docs/tree/complete-cloud-section) | #75 alone |

Because the branches are stacked, the `docs-playground` preview necessarily includes the #75 changes as well.
