### PR TITLE
Fix stale command links after run-locally/commands consolidation

### DIFF
--- a/src/content/core-concepts/architecture-overview.mdx
+++ b/src/content/core-concepts/architecture-overview.mdx
@@ -54,8 +54,8 @@ Every box in the diagram maps to a directory in the [browser repository](https:/
 
 The same engine runs behind these entry points. Each is a different way to drive it, and each has different availability across [local and cloud](/core-concepts/local-vs-cloud#feature-coverage):
 
-- [`fetch`](/run-locally/commands/fetch) loads one or more URLs and dumps the result to stdout as HTML or Markdown. It is a one-shot command with no server.
-- [`serve`](/run-locally/commands/serve) starts a CDP server on port `9222` by default. Clients like [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) connect over the Chrome DevTools Protocol. This is the mode most automation uses.
+- [`fetch`](/run-locally/commands#fetch) loads one or more URLs and dumps the result to stdout as HTML or Markdown. It is a one-shot command with no server.
+- [`serve`](/run-locally/commands#serve) starts a CDP server on port `9222` by default. Clients like [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) connect over the Chrome DevTools Protocol. This is the mode most automation uses.
 - [`agent`](/usage/agent) starts an interactive AI agent that browses the web from natural language and can record reproducible scripts.
 - [`mcp`](/usage/mcp) starts a Model Context Protocol server over stdio, so an LLM host can use the browser as a tool.
 - The [HTTP API](/usage/api) is a `POST /api/fetch` endpoint that returns a page's HTML or Markdown from a single request, no CDP script needed. It is the cloud's equivalent of the local `fetch` command.

--- a/src/content/core-concepts/local-vs-cloud.mdx
+++ b/src/content/core-concepts/local-vs-cloud.mdx
@@ -11,7 +11,7 @@ Lightpanda runs the same engine two ways. You can run the binary yourself, on yo
 
 ## Choose local or cloud
 
-**Run local when** you want full control and want nothing to leave your machine. The binary runs on your hardware, so pages you visit and data you extract stay in your infrastructure. Local gives you every interface: the [CDP server](/run-locally/commands/serve), the [MCP server](/usage/mcp) with all tools, and the built-in [AI agent](/usage/agent). You manage the process, the scaling, and the network egress yourself.
+**Run local when** you want full control and want nothing to leave your machine. The binary runs on your hardware, so pages you visit and data you extract stay in your infrastructure. Local gives you every interface: the [CDP server](/run-locally/commands#serve), the [MCP server](/usage/mcp) with all tools, and the built-in [AI agent](/usage/agent). You manage the process, the scaling, and the network egress yourself.
 
 **Use the cloud when** you do not want to run or scale browsers. You sign up, get a token, and connect a remote browser with no process to manage and no host to keep alive. Lightpanda Cloud runs the browser on its servers and adds the parts a hosted service needs: a [console](https://console.lightpanda.io) to manage your account and tokens and review recent sessions, usage-based plans with concurrency and monthly limits, a managed proxy pool that helps when a target blocks datacenter IPs, and an [HTTP API](/usage/api) that returns a page's HTML or Markdown from a single request with no CDP script. Because requests run on Lightpanda's servers, your target URLs and the fetched content pass through Lightpanda's infrastructure.
 
@@ -33,11 +33,11 @@ Cloud coverage is a work in progress. The cloud exposes the MCP server over SSE 
 
 | Interface / feature | Local | Cloud |
 | --- | --- | --- |
-| [CDP server](/run-locally/commands/serve) (`serve`) | Yes | Yes |
+| [CDP server](/run-locally/commands#serve) (`serve`) | Yes | Yes |
 | [MCP server](/usage/mcp) | Yes, all tools | Partial, subset of tools |
 | [AI agent](/usage/agent) | Yes | No |
-| [`fetch` command](/run-locally/commands/fetch) | Yes | No |
+| [`fetch` command](/run-locally/commands#fetch) | Yes | No |
 | [HTTP API](/usage/api) | No | Yes |
 | [Proxies](/guides/configure-a-proxy) | Yes, your own proxy | Yes, managed rotating pool with country selection |
 
-For CDP, both modes speak the same protocol: the same [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) scripts run against a local endpoint or a cloud endpoint with your token. The [HTTP API](/usage/api) is the cloud counterpart to the local [`fetch`](/run-locally/commands/fetch) command: both return one-shot HTML or Markdown with no CDP script. See [Getting started](/run-on-lightpanda-cloud/getting-started) to connect to the cloud.
+For CDP, both modes speak the same protocol: the same [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) scripts run against a local endpoint or a cloud endpoint with your token. The [HTTP API](/usage/api) is the cloud counterpart to the local [`fetch`](/run-locally/commands#fetch) command: both return one-shot HTML or Markdown with no CDP script. See [Getting started](/run-on-lightpanda-cloud/getting-started) to connect to the cloud.


### PR DESCRIPTION
## Summary
- `core-concepts/architecture-overview.mdx` and `core-concepts/local-vs-cloud.mdx` (merged via `complete-cloud-section`, before the reference-section split) still linked to `/run-locally/commands/fetch` and `/run-locally/commands/serve`, which #76 consolidated into `/run-locally/commands#fetch` and `/run-locally/commands#serve`
- These are redirected so not actually broken, but pointing at the final anchors directly is cleaner than relying on the redirect