### PR TITLE
Add Keenable to the search tool docs and drop the removed DuckDuckGo engine

### DIFF
--- a/src/content/reference/cli/agent.mdx
+++ b/src/content/reference/cli/agent.mdx
@@ -135,7 +135,7 @@ Inside the REPL, slash commands work alongside natural-language input:
 | `/model [name]` | Change the model |
 | `/provider [name]` | Change the provider, or `null` to disable the LLM |
 
-**Search engine keys.** In `auto` mode (the default), search tries Brave, Tavily, Exa, then Keenable, using each only if its key (`BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `KEENABLE_API_KEY`) is set. Keenable also works without a key through its public endpoint (rate-limited per client IP), so no key is required.
+**Search engine.** An API key is optional. By default (`auto` mode) search uses Keenable's keyless public endpoint, rate-limited per client IP. To route through a specific provider, set `BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, or `KEENABLE_API_KEY`; `auto` tries Brave, Tavily, Exa, then Keenable in that order, using whichever keys are set.
 
 Three commands send a prebuilt prompt to the model instead of configuring the REPL:
 

--- a/src/content/reference/cli/agent.mdx
+++ b/src/content/reference/cli/agent.mdx
@@ -126,7 +126,7 @@ Inside the REPL, slash commands work alongside natural-language input:
 | `/verbosity <level>` | Set agent verbosity (`low`, `medium`, `high`) |
 | `/effort <level>` | Set per-turn reasoning effort (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`) |
 | `/stream [on\|off]` | Toggle streaming of assistant text |
-| `/searchEngine <engine>` | Change the web search engine (`auto`, `tavily`, `brave`, `exa`, `duckduckgo`) |
+| `/searchEngine <engine>` | Change the web search engine (`auto`, `brave`, `tavily`, `exa`, `keenable`) |
 | `/usage` | Show token usage and cache stats for this session |
 | `/clear` | Clear conversation history and usage (keeps page and cookies) |
 | `/reset` | Reset conversation and browser session (drops page and cookies) |
@@ -134,6 +134,8 @@ Inside the REPL, slash commands work alongside natural-language input:
 | `/load <path>` | Load and run a script from disk |
 | `/model [name]` | Change the model |
 | `/provider [name]` | Change the provider, or `null` to disable the LLM |
+
+**Search engine keys.** In `auto` mode (the default), search tries Brave, Tavily, Exa, then Keenable, using each only if its key (`BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `KEENABLE_API_KEY`) is set. Keenable also works without a key through its public endpoint (rate-limited per client IP), so no key is required.
 
 Three commands send a prebuilt prompt to the model instead of configuring the REPL:
 

--- a/src/content/reference/mcp-tools.mdx
+++ b/src/content/reference/mcp-tools.mdx
@@ -30,7 +30,7 @@ These tools bring a page into the browser:
 | Name | Arguments | Description |
 |---|---|---|
 | `goto` | `url`, `timeout?`, `waitUntil?` | Navigate to a specified URL and load the page in memory so it can be reused later for info extraction. `waitUntil` accepts the same states as `waitForState` and defaults to `load`; prefer `domcontentloaded` plus a follow-up `waitForSelector` on pages whose late scripts (ads) hold `load` back, and avoid `done` on pages with constant background activity, since it can run to the timeout. |
-| `search` | `query`, `timeout?` | Run a web search and return results as markdown. When `BRAVE_API_KEY`, `TAVILY_API_KEY` or `EXA_API_KEY` is set, queries that search API (in that preference order) and returns a numbered list of `{title, url, snippet}`. Otherwise (or on API failure) falls back to scraping the DuckDuckGo HTML endpoint; degraded results, may rate-limit on bursty traffic. Prefer this over goto-ing google.com/search directly (Google blocks the browser on User-Agent/TLS). Browser state after this call is unspecified; to interact with a result, use `goto` with its URL; do not assume the browser DOM matches the results page. |
+| `search` | `query`, `timeout?` | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. Search tries brave, tavily, exa, then keenable in order, each when its API key (`BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY` or `KEENABLE_API_KEY`) is set; keenable also works without a key through its public endpoint (rate-limited per client IP). Prefer this over goto-ing google.com/search directly (Google blocks the browser on User-Agent/TLS). The browser does not navigate; to open a result, use `goto` with its URL. |
 
 ## Reading the page
 

--- a/src/content/usage/agent.mdx
+++ b/src/content/usage/agent.mdx
@@ -164,6 +164,19 @@ The schema is parsed in Zig before the page-side walker runs, so malformed
 schemas are rejected up front with a plain `Error: InvalidParams` rather
 than a V8 stack trace.
 
+### Web search
+
+`/searchEngine <engine>` sets the backend the agent's web search runs
+against: `auto` (the default), `brave`, `tavily`, `exa`, or `keenable`.
+The choice is saved per-directory in `.lp-agent.zon`.
+
+An API key is optional. `auto` falls back to Keenable's keyless public
+endpoint (rate-limited per client IP), so search works with no setup.
+Setting `BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, or
+`KEENABLE_API_KEY` routes `auto` through that provider instead. See the
+[command reference](/reference/cli/agent#repl-commands) for the resolution
+order.
+
 ### Meta commands
 
 Meta commands don't drive the browser, they control the REPL itself:

--- a/src/content/usage/mcp.mdx
+++ b/src/content/usage/mcp.mdx
@@ -176,6 +176,17 @@ Execute arbitrary JavaScript in the page context and return the result as a stri
 {"result":{"content":[{"type":"text","text":"Example Domain"}],"isError":false}}
 ```
 
+### `search`
+
+`search` queries a search API and returns the results as a numbered markdown list of `{title, url, snippet}`. It doesn't load a page, so open a result with `goto`.
+
+```json copy
+{"jsonrpc":"2.0","id":6,"method":"tools/call",
+ "params":{"name":"search","arguments":{"query":"lightpanda browser"}}}
+```
+
+> An API key is optional. Without one, search uses Keenable's keyless public endpoint (rate-limited per client IP). Set `BRAVE_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, or `KEENABLE_API_KEY` in the server's environment to route through that provider.
+
 ### Resources
 
 Three read-only resources are available via `resources/read`. The two page resources need a loaded page; `mcp://skill/pandascript` doesn't, so an MCP host can fetch it up front to teach its own LLM how to write PandaScript before ever touching the browser.


### PR DESCRIPTION
- Sync the `search` tool docs (MCP tools reference + agent `/searchEngine`) with the browser: the engine cascade is now Brave, Tavily, Exa, Keenable, and Keenable's keyless endpoint replaces the removed DuckDuckGo fallback.
- Document the keyless default: a "Search engine" note in the agent CLI reference, and short web-search sections in the agent and MCP usage pages.