### PR TITLE
sync docs with 0.4.0 browser release

### DIFF
--- a/src/content/reference/cli/agent.mdx
+++ b/src/content/reference/cli/agent.mdx
@@ -27,7 +27,6 @@ Options:
           Feed a local file to the model alongside --task. Repeatable, one
           file per flag. Text files are inlined (max 512 KiB each);
           images/audio/pdf are base64-encoded (max 20 MiB each).
-          Unsupported MIME types fail before any browser work runs.
           Requires --task.
   --base-url <URL>
           Override the API base URL for the provider. Defaults to the

--- a/src/content/reference/cli/common-options.mdx
+++ b/src/content/reference/cli/common-options.mdx
@@ -11,6 +11,10 @@ Every Lightpanda command ([fetch](/reference/cli/fetch), [serve](/reference/cli/
 
 ```console
 common options:
+  --adblock-lists <LIST>
+          EasyList-syntax filter files to load. Can be passed multiple times.
+          Requests to a hostname blocked by any list are failed before they leave.
+          e.g. --adblock-lists easylist.txt --adblock-lists easyprivacy.txt
   --block-cidrs <CIDR>
           Additional CIDR ranges to block. Can be passed multiple times.
           Prefix with '-' to allow (exempt from blocking).

--- a/src/content/reference/cli/common-options.mdx
+++ b/src/content/reference/cli/common-options.mdx
@@ -40,20 +40,26 @@ common options:
   --cookie-jar <PATH>
           Path to a JSON file to save cookies to on exit (write-only).
           Defaults to no cookie saving.
-  --disable-subframes
-          Skip loading <iframe> elements. The parser still registers them in the
-          DOM, but no child frame or Page.frameAttached events are produced.
-          Defaults to false.
-  --disable-workers
-          Skip loading dedicated Web Workers. The Worker constructor still
-          returns a Worker object, but no script fetch is initiated and its scope
-          never runs.
-          Defaults to false.
-  --enable-external-stylesheets
-          Fetch external <link rel=stylesheet> resources so their rules
-          contribute to computed styles (and therefore to visibility checks like
-          display, visibility, opacity, pointer-events).
-          Defaults to false, except in agent mode with an LLM, where it is on.
+  --load-resources <RESOURCE>
+          Sub-resource to actually request. Can be passed multiple times.
+          Defaults to requesting none of them.
+          Allowed values:
+             iframe      When enabled, <iframe> elements are fully loaded.
+
+             image       <img> sources, so that load/error reflects the real
+                         HTTP status. Only the response headers are read;
+                         images are never decoded, so naturalWidth and
+                         naturalHeight stay 0. Delays the window load event.
+
+             stylesheet  Fetch external <link rel=stylesheet> resources so
+                         their rules contribute to computed styles (and
+                         therefore to visibility checks like display,
+                         visibility, opacity, pointer-events).
+
+             worker      Enable loading dedicated and shared workers. When
+                         disabled, the Worker constructor still returns a
+                         Worker, but no script fetch is initiated and the
+                         Worker never runs.
   --http-cache-dir <PATH>
           Directory used as a filesystem cache for network resources. Omitting
           this disables caching.
@@ -101,16 +107,21 @@ common options:
   --http-timeout <INT>
           Maximum time in ms the transfer is allowed to complete. 0 means never.
           Defaults to 10000.
+  --http-version <VERSION>
+          HTTP version to negotiate. "1.1" never offers HTTP/2. "auto"
+          picks the best available option.
+          Defaults to "auto".
+          Allowed values: "auto", "1.1".
   --insecure-disable-tls-host-verification
           Disables host verification on all HTTP requests.
           Only set this if you understand and accept the risk.
-  --log-filter-scopes <SCOPE>
+  --log-filter <SCOPE>
           Filter logs per scope, applied first-to-last. Can be passed multiple times.
           "-X" (or bare "X") filters out a scope, "+X" filters it in, and
           "all" targets every scope.
-          e.g. --log-filter-scopes http --log-filter-scopes unknown_prop
+          e.g. --log-filter http --log-filter unknown_prop
           hides those two.
-          --log-filter-scopes -all --log-filter-scopes +cdp
+          --log-filter -all --log-filter +cdp
           hides everything except cdp.
   --log-format <FORMAT>
           The log format.
@@ -166,3 +177,10 @@ common options:
           Maximum number of concurrent WebSocket connections.
           Defaults to 8.
 ```
+
+**Deprecated options.** Still accepted, but no longer shown in `--help`:
+
+- **`--disable-subframes`**: subframes are now disabled by default, use `--load-resources iframe` to enable.
+- **`--disable-workers`**: workers are now disabled by default, use `--load-resources worker` to enable.
+- **`--enable-external-stylesheets`**: use `--load-resources stylesheet` to enable.
+- **`--log-filter-scopes`**: use `--log-filter` instead.

--- a/src/content/reference/cli/fetch.mdx
+++ b/src/content/reference/cli/fetch.mdx
@@ -19,8 +19,22 @@ options:
           Allowed values:
               html               Serialized HTML of the DOM.
               markdown           Converts content to Markdown.
+              png                Text-only rendering of the page as a
+                                 PNG image (base64 with --json).
               semantic_tree      JSON-serialized semantic tree.
               semantic_tree_text Pruned plain-text semantic tree.
+  --dump-max-bytes <INT>
+          Soft cap on the dumped html or markdown, in bytes. Output is cut
+          at a UTF-8 boundary and a '[truncated]' marker is appended.
+          Defaults to no cap.
+  --dump-selector <QUERY>
+          Dump only the first element matching the CSS selector instead
+          of the whole document. Fails if nothing matches.
+  --fail-on-http-error
+          Exit with code 22 when any page's HTTP status is 400 or above.
+          The dump is still written. Navigation and wait failures exit
+          with code 1 regardless of this flag.
+          Defaults to false.
   --inject-script <EXPR>
           JavaScript to execute as the document's <head> is parsed, before any
           other scripts in the page run. Can be passed multiple times; scripts
@@ -32,13 +46,18 @@ options:
           Capture and print the status of the fetch as JSON. A single URL
           prints one object; multiple URLs print {"results": [ ... ]} with
           one object per URL. When used with --dump <MODE> the dumped
-          content is wrapped within each object.
+          content is wrapped within each object. Each object carries an
+          "error" field: null, or the name of the navigation, wait or
+          dump failure for that URL. One failed URL does not stop the
+          others; the process exits 1 if any URL failed.
   --metrics
           Write metrics (Prometheus text format) to stdout on exit, after
           any --dump output.
           Defaults to false.
   --strip-mode <STRIP>
           Tag group to remove from dump. Can be passed multiple times.
+          In markdown only 'ui' changes the output: scripts, styles and
+          hidden elements are never rendered.
           Defaults to no-strip.
           Allowed values:
               js        Script and link[as=script, rel=preload].
@@ -69,6 +88,9 @@ options:
           --wait-script-file specified, defaults to none.
           Allowed values: "load", "domcontentloaded", "networkalmostidle",
           "networkidle", "done".
+          'done' waits for full quiescence (no pending scripts or network);
+          pages with constant background activity never reach it and run
+          to --wait-ms.
   --with-base
           Add a <base> tag in dump.
           Defaults to false.

--- a/src/content/reference/cli/serve.mdx
+++ b/src/content/reference/cli/serve.mdx
@@ -38,6 +38,14 @@ options:
   --port <INT>
           Port of the CDP server.
           Defaults to 9222.
+  --protocol <PROTOCOL>
+          Automation protocol to serve. Can be passed multiple times to
+          serve several on the same port.
+          Defaults to cdp.
+          Allowed values:
+              cdp        Chrome DevTools Protocol (WebSocket on /).
+              webdriver  WebDriver BiDi (WebSocket on /session) plus the
+                         classic WebDriver session endpoints.
 ```
 
 The command also accepts the [common options](/reference/cli/common-options).

--- a/src/content/reference/mcp-tools.mdx
+++ b/src/content/reference/mcp-tools.mdx
@@ -38,12 +38,13 @@ These tools read the loaded page without modifying it:
 
 | Name | Arguments | Description |
 |---|---|---|
-| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | Render the page, or a subtree, as markdown. |
-| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | Raw HTML for the document, or a single node's outerHTML when scoped. |
-| `tree` | `backendNodeId?`, `maxDepth?`, `url?`, `timeout?` | Simplified semantic DOM tree: role, name, value, and backendNodeId per node. |
-| `links` | `url?`, `timeout?` | Extract all links as `text` (visible anchor text), `href` (resolved URL), and `backendNodeId`. |
-| `nodeDetails` | `backendNodeId` | Tag, role, name, attributes, and state for a node, plus a ready-to-use CSS selector. |
-| `findElement` | `role?`, `name?` | Find interactive elements by role and/or accessible name. |
+| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region: full-page markdown is the last resort. Use `maxBytes` to cap long pages. |
+| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. |
+| `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file at full size and returns its location; without it, returns the image inline where the client can display one, at most 1280px wide and 4096px tall. Use it to see spatial layout; read content with `markdown`/`tree`. |
+| `tree` | `backendNodeId?`, `maxDepth?`, `url?`, `timeout?` | Simplified semantic DOM tree: role, name, value, and backendNodeId per node. Pass `backendNodeId` to scope, `maxDepth` to limit depth. |
+| `links` | `url?`, `timeout?` | Extract all links as `text` (visible anchor text, falling back to aria-label/title/image alt), `href` (resolved URL), and `backendNodeId` (pass to click/nodeDetails). One entry per href; hidden links are omitted. |
+| `nodeDetails` | `backendNodeId` | Tag, role, name, interactivity, disabled, value, input type, placeholder, href, id, class, checked, select options, and state for a node, plus a ready-to-use CSS `selector` that resolves to the node (the first match, as click/fill resolve it). The canonical way to turn a tree backendNodeId into a CSS selector. |
+| `findElement` | `role?`, `name?` | Find interactive elements by role and/or accessible name. Returns matching elements with their backend node IDs. Useful for locating specific elements without parsing the full semantic tree. |
 | `interactiveElements` | `url?`, `timeout?` | Extract interactive elements from the page. |
 | `structuredData` | `url?`, `timeout?` | Extract structured data (like JSON-LD, OpenGraph, etc) from the page. |
 | `detectForms` | `url?`, `timeout?` | Detect forms on the page: fields, types, and required status. |
@@ -56,8 +57,8 @@ These tools return structured results from the loaded page:
 
 | Name | Arguments | Description |
 |---|---|---|
-| `extract` | `schema`, `save?` | Extract structured data from the current page using a schema mapping output field names to CSS-selector specs. |
-| `evaluate` | `script`, `url?`, `timeout?`, `save?` | Evaluate JavaScript in the page context. A bare trailing expression yields its value; top-level `await` and `return` are supported. |
+| `extract` | `schema`, `save?` | Extract structured data from the current page (navigate first) using a schema mapping output field names to CSS-selector specs. |
+| `evaluate` | `script`, `url?`, `timeout?`, `save?` | Evaluate JavaScript in the page context. A bare trailing expression yields its value; top-level `await` and `return` are supported. This is an escape hatch for page-side logic the dedicated tools can't express: prefer `extract` for data and click/fill/etc. for actions. It runs in the page, so it cannot see the agent script's variables or builtins: interpolate any value into the `script` string. Objects and arrays return as JSON, so no `JSON.stringify` is needed. If a url is provided, it navigates there first. The `globalThis.lp` object exposes a Session-scoped bridge store: values written via `lp.foo = ...` auto-sync at end of evaluate, surviving navigation; values previously set via `/extract save=` or `/evaluate save=` appear as `lp.<name>`. |
 
 > `save` stores the result under a bridge key, available in later `evaluate` calls as `lp.<name>`.
 
@@ -94,8 +95,8 @@ These tools dispatch real DOM events on the page:
 | `click` | `selector` / `backendNodeId` | Click on an interactive element. Returns the current page URL and title after the click. |
 | `fill` | `selector` / `backendNodeId`, `value` | Fill text into an input element. Returns the filled value and current page URL and title. |
 | `scroll` | `backendNodeId?`, `x?`, `y?` | Scroll the page, or a specific element if `backendNodeId` is given. Returns the scroll position only. |
-| `hover` | `selector` / `backendNodeId` | Hover over an element, triggering mouseover and mouseenter events. |
-| `press` | `key`, `selector?`, `backendNodeId?` | Press a keyboard key, dispatching keydown and keyup events. Targets the document if no element is given. |
+| `hover` | `selector` / `backendNodeId` | Hover over an element, triggering mouseover and mouseenter events. Useful for menus, tooltips, and hover states. |
+| `press` | `key`, `selector?`, `backendNodeId?` | Press a keyboard key, dispatching keydown and keyup events. Use key names like 'Enter', 'Tab', 'Escape', 'ArrowDown', 'Backspace', or single characters like 'a', '1'. Common shorthand is normalized: 'enter'/'return' → 'Enter', 'esc' → 'Escape', 'up'/'down'/'left'/'right' → 'Arrow*', 'space' → ' '. Pressing 'Enter' on a form input or submit button triggers implicit form submission. Targets the document if no element is given. |
 | `selectOption` | `selector` / `backendNodeId`, `value` | Select an option in a `<select>` dropdown element by its value. Dispatches input and change events. |
 | `setChecked` | `selector` / `backendNodeId`, `checked?` | Check or uncheck a checkbox or radio button (defaults to checking it). Dispatches input, change, and click events. |
 
@@ -106,8 +107,8 @@ These tools block until the page reaches a condition:
 | Name | Arguments | Description |
 |---|---|---|
 | `waitForSelector` | `selector`, `timeout?` | Wait for an element matching a CSS selector to appear in the page. Returns the backend node ID of the matched element. |
-| `waitForScript` | `script`, `timeout?` | Wait until a JavaScript expression returns truthy, re-evaluating on each tick of the event loop. |
-| `waitForState` | `state`, `timeout?` | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
+| `waitForScript` | `script`, `timeout?` | Wait until a JavaScript expression returns truthy, re-evaluating on each tick of the event loop. Use for synchronization beyond what CSS selectors can express: e.g. `window.dataLoaded === true`, `document.readyState === 'complete'`, `document.querySelectorAll('.row').length >= 5`. |
+| `waitForState` | `state`, `timeout?` | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. After a `goto`, the page is returned at the fast `load` snapshot, so content rendered by post-load JS (XHR-loaded lists, feeds, search results) may still be missing. When a read looks incomplete: empty lists, spinners, skeletons; call this with 'networkidle' and re-read. Prefer 'networkidle'; 'done' can be slow on sites with constant background activity (ads, polling). |
 
 ## State and debugging
 
@@ -115,9 +116,9 @@ These tools inspect browser state outside the DOM:
 
 | Name | Arguments | Description |
 |---|---|---|
-| `getUrl` | — | Get the URL of the page currently loaded in the browser. |
-| `getCookies` | `url?`, `all?` | Get cookies stored in the browser. Defaults to the current page's host; pass `url` to filter another host or `all` to dump every cookie. |
-| `getEnv` | `name?` | Read an `LP_*` environment variable by name, or list the `LP_*` names that are set when called without a name. |
+| `getUrl` | — | Get the URL of the page currently loaded in the browser. Useful to verify a navigation or detect a redirect. |
+| `getCookies` | `url?`, `all?` | Get cookies stored in the browser. Defaults to the current page's host; pass `url` to filter another host or `all` to dump every cookie. Useful for debugging authentication and session state. |
+| `getEnv` | `name?` | With `name`: read an `LP_*` environment variable, for non-secret config only (base URLs, flags). Without `name`: list the `LP_*` names that are set, for safe credential discovery. For secrets, pass `$LP_*` placeholders in tool args; never request a credential by name. |
 | `consoleLogs` | — | Get buffered console.log/warn/error messages from the current page, then clear the buffer. |
 
 ## Session

--- a/src/content/reference/pandascript.mdx
+++ b/src/content/reference/pandascript.mdx
@@ -20,14 +20,15 @@ The script context installs two globals, `Page` and [`console`](#console), and n
 | `page.goto` | `goto(url[, { timeout = 10000, waitUntil = "load" }])` | The same page object it was called on | Resolves once `waitUntil` is reached. `waitUntil` takes the same states as [`waitForState`](#waiting): `load` (default, a fast snapshot that skips content rendered by post-load JavaScript), `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`. |
 | `page.close` | `close()` | Nothing | Stales the handle, so later calls on it fail. The page itself is reclaimed on the next `goto` or at script end. |
 
-## Extraction and page scripting
+## Reading the page
 
-`evaluate` runs a JavaScript string inside the page, where `window` and `document` exist, and `extract` resolves its schema selectors there too. That code runs in the page, so it cannot see the variables of your agent script.
+`evaluate` runs a JavaScript string inside the page, where `window` and `document` exist, and `extract` resolves its schema selectors there too. That code runs in the page, so it cannot see the variables of your agent script. `screenshot` doesn't run any page JavaScript; it renders the same computed layout `extract` and markdown read as a PNG instead of text.
 
 | Primitive | Arguments | Returns | Comment |
 |-----------|-----------|---------|---------|
 | `page.extract` | `extract(schema)` or `extract({ schema })` | An object or an array, shaped by the schema | Schema forms are listed [below](#extraction-schema). |
 | `page.evaluate` | `evaluate(script[, { url, timeout = 10000, save }])` | The page value as a string, JSON-encoded when it is an object or array | `url` navigates before running the script, and `timeout` bounds that navigation, not the script. |
+| `page.screenshot` | `screenshot({ path, selector?, backendNodeId?, fullPage?, url?, timeout? })`, never positional | `Saved <width>x<height> PNG to <path>` | `path` is required in scripts: a script cannot display an inline image, so omitting it throws `pass \`path\`: this client cannot display an inline image`. Renders the page, or one scoped node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colours). |
 
 ### Extraction schema
 

--- a/src/content/usage/mcp.mdx
+++ b/src/content/usage/mcp.mdx
@@ -168,8 +168,19 @@ Execute arbitrary JavaScript in the page context and return the result as a stri
 ```json copy
 {"jsonrpc":"2.0","id":3,"method":"tools/call",
  "params":{"name":"evaluate","arguments":{
-   "script":"document.title",
+   "script":"lp.title = document.title",
    "url":"https://example.com"}}}
+```
+
+```json
+{"result":{"content":[{"type":"text","text":"Example Domain"}],"isError":false}}
+```
+
+Assigning to `globalThis.lp` here, instead of a local variable, carries the value forward: `lp` lives in the Lightpanda session, not the page, so it's still there in a later `evaluate` call, even after navigating away (a plain JS variable would be gone):
+
+```json copy
+{"jsonrpc":"2.0","id":4,"method":"tools/call",
+ "params":{"name":"evaluate","arguments":{"script":"lp.title"}}}
 ```
 
 ```json

--- a/src/content/usage/pandascript.mdx
+++ b/src/content/usage/pandascript.mdx
@@ -114,9 +114,9 @@ arrays, plain objects, and `null` work. Find what the other values throw in the
 ## Installed Primitives
 
 Only recorded browser primitives are installed globally: `new Page()`, then
-`goto`, `extract`, `evaluate`, the interaction methods and the `waitFor*`
-methods as methods on the page. Find the full table, the calling conventions
-and the timeouts in the [PandaScript reference](/reference/pandascript).
+`goto`, `extract`, `evaluate`, `screenshot`, the interaction methods and the
+`waitFor*` methods as methods on the page. Find the full table, the calling
+conventions and the timeouts in the [PandaScript reference](/reference/pandascript).
 
 ## Navigation
 


### PR DESCRIPTION
- Sync `reference/cli/*.mdx` with `help.zon`/`Config.zig` at the `0.4.0` tag: document `--load-resources`, `--http-version`, `--protocol`, `--dump-max-bytes`, `--dump-selector`, `--fail-on-http-error`, and the `png` dump format; move `--disable-subframes`, `--disable-workers`, `--enable-external-stylesheets`, and `--log-filter-scopes` to a "Deprecated options" note since `Config.zig` still accepts them; drop an unsourced sentence from `--attach`.
- Restore several MCP tool descriptions in `reference/mcp-tools.mdx` that had been trimmed past the point of losing real content (`nodeDetails`, `links`, `evaluate`, `waitForState`, others), and document the previously-missing `screenshot` tool.
- Rewrite the `globalThis.lp` bridge-store example in `usage/mcp.mdx` with a concrete before/after instead of unexplained terminology.
- Document the `screenshot` primitive in `reference/pandascript.mdx`, grouped with `extract`/`evaluate` under a renamed "Reading the page" section since it shares the same content-analysis code as markdown extraction.
- Document `--adblock-lists`, previously withheld until the feature was ready to announce.