### PR TITLE
Fix quickstart npm install to also fetch the Lightpanda binary

### DIFF
--- a/src/content/quickstart.mdx
+++ b/src/content/quickstart.mdx
@@ -42,23 +42,20 @@ directory should look like this:
 
 ### Install Lightpanda dependency
 
-Install Lightpanda by using the [official npm package](https://www.npmjs.com/package/@lightpanda/browser).
+Install Lightpanda's [npm package](https://www.npmjs.com/package/@lightpanda/browser), then download the browser binary with its `install` command.
 
-<Tabs items={['npm', 'yarn', 'pnpm']} className="-mb-4">
+<Tabs items={['npm', 'pnpm']} className="-mb-4">
   <Tabs.Tab id="npm" className="m-0">
     ```sh copy
     npm install --save @lightpanda/browser
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab id="yarn" className="m-0">
-    ```sh copy
-    yarn add @lightpanda/browser
+    npx @lightpanda/browser install
     ```
   </Tabs.Tab>
   <Tabs.Tab id="pnpm" className="m-0">
-  ```sh copy
-  pnpm add @lightpanda/browser
-  ```
+    ```sh copy
+    pnpm add @lightpanda/browser
+    npx @lightpanda/browser install
+    ```
   </Tabs.Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary
- Installing `@lightpanda/browser` via npm only gets the JS library, not the browser binary, so `npm install --save @lightpanda/browser` alone leaves `lightpanda.serve()` with nothing to spawn. Added `npx @lightpanda/browser install` as a second step in the npm and pnpm tabs.
- Preferred `npx @lightpanda/browser install` over the curl one-liner (`pkg.lightpanda.io/install.sh`) because it uses the `get.lightpanda.io/versions.json` endpoint, more reliable than `api.github.com`, which the one-liner (and the package's own broken `postinstall` script) depends on and which is prone to rate-limiting.
- Dropped the yarn tab: `@lightpanda/browser`'s `package.json` declares `"engines": {"yarn": "4"}`, so `yarn add` hard-fails on Yarn Classic (v1), the default most people have.
- Refined the intro sentence for the install step.