### PR TITLE
Add a Python SDK guide and reference page

### DIFF
--- a/src/content/guides/_meta.ts
+++ b/src/content/guides/_meta.ts
@@ -6,6 +6,7 @@ const meta: MetaRecord = {
   'configure-a-proxy': 'Configure a proxy',
   'markdown-axtree': 'Get Markdown and AX Tree',
   'interact-with-a-webpage': 'Interact with a webpage',
+  'use-python': 'Use the Python SDK',
   'use-stagehand': 'Use Stagehand',
   'use-hermes': 'Use Hermes Agent',
 }

--- a/src/content/guides/use-python.mdx
+++ b/src/content/guides/use-python.mdx
@@ -8,7 +8,7 @@ import { Callout, Tabs } from 'nextra/components'
 
 In this guide, you'll scrape a JavaScript-rendered page with the [`lightpanda` Python package](https://pypi.org/project/lightpanda/) and extract structured data from it with `page.extract`.
 
-The package bundles the Lightpanda browser binary, so there's no CDP client to wire up and no separate browser download, unlike driving Lightpanda from [Puppeteer or Playwright](/guides/retrieve-an-html-webpage). It also runs [an order of magnitude less memory than a Selenium and Chrome stack](https://github.com/lightpanda-io/lightpanda-python/blob/main/examples/compare.py) for the same scrape.
+The package bundles the Lightpanda browser binary, so there's no CDP client to wire up and no separate browser download, unlike driving Lightpanda from [Puppeteer or Playwright](/guides/retrieve-an-html-webpage). It also uses [an order of magnitude less memory than a Selenium and Chrome stack](https://github.com/lightpanda-io/lightpanda-python/blob/main/examples/compare.py) for the same scrape.
 
 ## Prerequisites
 
@@ -121,6 +121,8 @@ Top tags: [('love', 14), ('inspirational', 13), ('life', 13), ('humor', 12), ('b
 
 Use `AsyncBrowser` instead of `Browser` when you want to scrape many pages at once instead of one after another, or when your code already runs inside an async application (a web server built with FastAPI, for example) where a blocking call would freeze everything else it's doing. Every method becomes awaitable; `AsyncBrowser` itself runs each call on the browser's own thread pool, so it never blocks your event loop.
 
+Since the site's ten pages are numbered, fetch all of them at once with `asyncio.gather` instead of following the pagination link one page at a time. `browser.session()` opens a session scoped to one task and closes it when that task ends:
+
 ```python copy
 import asyncio
 from collections import Counter
@@ -134,24 +136,26 @@ SCHEMA = {
             "fields": {"text": ".text", "author": ".author", "tags": [".tag"]},
         }
     ],
-    "next": {"selector": "li.next a", "attr": "href"},
 }
+
+URLS = [f"https://quotes.toscrape.com/js/page/{n}/" for n in range(1, 11)]
+
+
+async def scrape_one(browser, url):
+    async with browser.session() as page:
+        await page.goto(url=url)
+        data = await page.extract(schema=SCHEMA)
+        return data["quotes"]
 
 
 async def main():
     async with AsyncBrowser() as browser:
-        page = await browser.new_session()
-        quotes = []
-        url = "https://quotes.toscrape.com/js/"
-        while url:
-            await page.goto(url=url)
-            data = await page.extract(schema=SCHEMA)
-            quotes.extend(data["quotes"])
-            url = data["next"]
+        results = await asyncio.gather(*(scrape_one(browser, url) for url in URLS))
+    quotes = [quote for page_quotes in results for quote in page_quotes]
 
-        print(f"{len(quotes)} quotes")
-        tags = Counter(tag for q in quotes for tag in q["tags"])
-        print("Top tags:", tags.most_common(5))
+    print(f"{len(quotes)} quotes")
+    tags = Counter(tag for q in quotes for tag in q["tags"])
+    print("Top tags:", tags.most_common(5))
 
 asyncio.run(main())
 ```
@@ -164,12 +168,12 @@ Find every method's arguments in the [Python SDK reference](/reference/python).
 
 ## Replay a saved script
 
-If you already have a PandaScript, a `.lp.js` file recorded by [Lightpanda Agent](/guides/lightpanda-agent-tutorial) or the MCP `save` tool, replay it from Python with `run_script`, no LLM call needed:
+If you already have a PandaScript, a `.js` file recorded by [Lightpanda Agent](/guides/lightpanda-agent-tutorial) or the MCP `save` tool, replay it from Python with `run_script`, no LLM call needed:
 
 ```python copy
 from lightpanda import run_script
 
-output = run_script("scrape.lp.js")
+output = run_script("scrape.js")
 print(output)
 ```
 

--- a/src/content/guides/use-python.mdx
+++ b/src/content/guides/use-python.mdx
@@ -1,0 +1,176 @@
+---
+title: Use the Python SDK
+description: Learn how to scrape a JavaScript-rendered webpage and extract structured data with the Lightpanda Python package.
+---
+import { Callout, Tabs } from 'nextra/components'
+
+# Use the Lightpanda Python SDK
+
+In this guide, you'll scrape a JavaScript-rendered page with the [`lightpanda` Python package](https://pypi.org/project/lightpanda/) and extract structured data from it with `page.extract`.
+
+The package bundles the Lightpanda browser binary, so there's no CDP client to wire up and no separate browser download, unlike driving Lightpanda from [Puppeteer or Playwright](/guides/retrieve-an-html-webpage). It also runs [an order of magnitude less memory than a Selenium and Chrome stack](https://github.com/lightpanda-io/lightpanda-python/blob/main/examples/compare.py) for the same scrape.
+
+## Prerequisites
+
+You'll need Python 3.10 or newer.
+
+Install the [`lightpanda` package](https://pypi.org/project/lightpanda/) from PyPI.
+
+<Tabs items={['pip', 'uv']} className="-mb-4">
+  <Tabs.Tab id="pip" className="m-0">
+```sh copy
+pip install lightpanda
+```
+  </Tabs.Tab>
+  <Tabs.Tab id="uv" className="m-0">
+```sh copy
+uv add lightpanda
+```
+  </Tabs.Tab>
+</Tabs>
+
+## Create scrape.py
+
+Create a `scrape.py` file. Import `Browser` and open a session:
+
+```python copy
+from lightpanda import Browser
+
+with Browser() as browser, browser.new_session() as page:
+    pass
+```
+
+`Browser()` starts the bundled Lightpanda binary and stops it when the `with` block exits.
+
+## Navigate and extract
+
+Use `page.goto` to load [quotes.toscrape.com/js](https://quotes.toscrape.com/js/), a page whose quotes are rendered by client-side JavaScript. Then call `page.extract` with a schema describing the fields to pull from each `.quote` element:
+
+```python copy
+SCHEMA = {
+    "quotes": [
+        {
+            "selector": ".quote",
+            "fields": {"text": ".text", "author": ".author", "tags": [".tag"]},
+        }
+    ],
+}
+
+page.goto(url="https://quotes.toscrape.com/js/")
+data = page.extract(schema=SCHEMA)
+print(data["quotes"])
+```
+
+`extract` returns each `.quote` element as a record, with `tags` resolved to a list of every `.tag` inside it. A plain `requests.get` on this page returns zero quotes because the DOM is only built after the page's JavaScript runs.
+
+## Full script
+
+Follow the site's own "Next" link to collect every page instead of just the first:
+
+```python copy
+from collections import Counter
+
+from lightpanda import Browser
+
+SCHEMA = {
+    "quotes": [
+        {
+            "selector": ".quote",
+            "fields": {"text": ".text", "author": ".author", "tags": [".tag"]},
+        }
+    ],
+    "next": {"selector": "li.next a", "attr": "href"},
+}
+
+with Browser() as browser, browser.new_session() as page:
+    quotes = []
+    url = "https://quotes.toscrape.com/js/"
+    while url:
+        page.goto(url=url)
+        data = page.extract(schema=SCHEMA)
+        quotes.extend(data["quotes"])
+        url = data["next"]
+
+    print(f"{len(quotes)} quotes")
+    tags = Counter(tag for q in quotes for tag in q["tags"])
+    print("Top tags:", tags.most_common(5))
+```
+
+## Run it
+
+<Tabs items={['pip', 'uv']} className="-mb-4">
+  <Tabs.Tab id="pip" className="m-0">
+```sh copy
+python scrape.py
+```
+  </Tabs.Tab>
+  <Tabs.Tab id="uv" className="m-0">
+```sh copy
+uv run scrape.py
+```
+  </Tabs.Tab>
+</Tabs>
+
+```sh
+$ python scrape.py
+100 quotes
+Top tags: [('love', 14), ('inspirational', 13), ('life', 13), ('humor', 12), ('books', 11)]
+```
+
+## Scrape concurrently with asyncio
+
+Use `AsyncBrowser` instead of `Browser` when you want to scrape many pages at once instead of one after another, or when your code already runs inside an async application (a web server built with FastAPI, for example) where a blocking call would freeze everything else it's doing. Every method becomes awaitable; `AsyncBrowser` itself runs each call on the browser's own thread pool, so it never blocks your event loop.
+
+```python copy
+import asyncio
+from collections import Counter
+
+from lightpanda import AsyncBrowser
+
+SCHEMA = {
+    "quotes": [
+        {
+            "selector": ".quote",
+            "fields": {"text": ".text", "author": ".author", "tags": [".tag"]},
+        }
+    ],
+    "next": {"selector": "li.next a", "attr": "href"},
+}
+
+
+async def main():
+    async with AsyncBrowser() as browser:
+        page = await browser.new_session()
+        quotes = []
+        url = "https://quotes.toscrape.com/js/"
+        while url:
+            await page.goto(url=url)
+            data = await page.extract(schema=SCHEMA)
+            quotes.extend(data["quotes"])
+            url = data["next"]
+
+        print(f"{len(quotes)} quotes")
+        tags = Counter(tag for q in quotes for tag in q["tags"])
+        print("Top tags:", tags.most_common(5))
+
+asyncio.run(main())
+```
+
+<Callout type="info" emoji="ℹ️">
+  Every browser method is available as a `Session` method, in both camelCase and snake_case (`waitForSelector` and `wait_for_selector` both work), typed and documented in your IDE.
+</Callout>
+
+Find every method's arguments in the [Python SDK reference](/reference/python).
+
+## Replay a saved script
+
+If you already have a PandaScript, a `.lp.js` file recorded by [Lightpanda Agent](/guides/lightpanda-agent-tutorial) or the MCP `save` tool, replay it from Python with `run_script`, no LLM call needed:
+
+```python copy
+from lightpanda import run_script
+
+output = run_script("scrape.lp.js")
+print(output)
+```
+
+`run_script` shells out to `lightpanda run <script>` and returns its stdout; a non-zero exit raises `ScriptError`. `run_script_async` is the awaitable variant.

--- a/src/content/reference/_meta.ts
+++ b/src/content/reference/_meta.ts
@@ -10,6 +10,7 @@ const meta: MetaRecord = {
   'http-api': 'HTTP API',
   'mcp-tools': 'MCP tools',
   pandascript: 'PandaScript',
+  python: 'Python SDK',
 }
 
 export default meta

--- a/src/content/reference/python.mdx
+++ b/src/content/reference/python.mdx
@@ -10,7 +10,7 @@ The [`lightpanda` package](https://pypi.org/project/lightpanda/) exposes `Browse
 
 ## Browser
 
-`Browser()` spawns the bundled binary on first use. It is not fork-inheritable: create a fresh instance in a forked child.
+`Browser()` spawns the bundled binary when constructed. It is not fork-inheritable: create a fresh instance in a forked child.
 
 | Argument | Default | Description |
 |---|---|---|
@@ -58,7 +58,7 @@ The [`lightpanda` package](https://pypi.org/project/lightpanda/) exposes `Browse
 | `close()` | Close the session. Calls made after `close()` raise `ToolError`. |
 | `call(action, **kwargs)` | Invoke any action by name. The methods documented below route through this. |
 
-`with session:` (or `async with`) calls `close()` on exit, if you obtained the session outside a `with Browser()`/`with browser.session()` block that already closes it.
+Sessions are context managers too: `with browser.new_session() as page:` closes the session on exit. Closing the browser ends every session anyway.
 
 ## Calling an action
 
@@ -68,42 +68,44 @@ Every browser action is a method on `Session`/`AsyncSession`, keyword-only. The 
   Only the method name gets a snake_case alias; its keyword arguments keep their original names. `wait_for_selector(selector=..., timeout=...)` has no case change, but `click(selector=..., backendNodeId=...)`, `screenshot(fullPage=...)`, and `tree(maxDepth=...)` all keep a camelCase keyword even though the method itself is snake_case.
 </Callout>
 
-A method returns parsed JSON for JSON-carrying results (`extract`, `links`, `structured_data`, `detect_forms`, `interactive_elements`, `find_element`), and plain text for everything else, including `tree`'s indented outline and `get_cookies`' `name=value` lines. A failed action raises `ToolError`.
+A failed action raises `ToolError`.
 
-In the Arguments column below, `?` marks an optional keyword argument, and `selector` / `backendNodeId` marks a pair where one of the two is required. Prefer `selector` for reproducibility; it also wins when you pass both. `backendNodeId` values come from a prior `tree`, `links`, or `find_element` call.
+In the Arguments column below, `?` marks an optional keyword argument, and `selector` / `backendNodeId` marks a pair where one of the two is required. Prefer `selector` for reproducibility; it also wins when you pass both. `backendNodeId` values come from a prior `tree`, `links`, or `find_element` call. In the Returns column, `JSON` is a parsed Python `dict` or `list`, `text` is a plain string.
 
 ### Navigation and search
 
 These methods bring a page into the browser:
 
-| Method | Arguments | Description |
-|---|---|---|
-| `goto` | `url`, `timeout?` | Navigate to a URL and load the page in memory so it can be reused later for info extraction. |
-| `search` | `query`, `timeout?` | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. The browser does not navigate; to open a result, call `goto` with its URL. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `goto` | `url`, `timeout?` | text | Navigate to a URL and load the page in memory so it can be reused later for info extraction. |
+| `search` | `query`, `timeout?` | text | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. The browser does not navigate; to open a result, call `goto` with its URL. |
 
 ### Reading the page
 
 These methods read the loaded page without modifying it:
 
-| Method | Arguments | Description |
-|---|---|---|
-| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region; use `maxBytes` to cap long pages. |
-| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. |
-| `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. The Python SDK doesn't request an inline image, so always pass `path`; without it you get a plain size summary, not the image itself. |
-| `tree` | `url?`, `timeout?`, `backendNodeId?`, `maxDepth?` | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
-| `links` | `url?`, `timeout?` | Every visible link as `text`, `href` (resolved to an absolute URL), and `backendNodeId`. |
-| `node_details` (`nodeDetails`) | `backendNodeId` | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
-| `find_element` (`findElement`) | `role?`, `name?` | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
-| `interactive_elements` (`interactiveElements`) | `url?`, `timeout?` | Every interactive element on the page. |
-| `structured_data` (`structuredData`) | `url?`, `timeout?` | Structured data on the page, such as JSON-LD or OpenGraph tags. |
-| `detect_forms` (`detectForms`) | `url?`, `timeout?` | Forms on the page: fields, types, and required status. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | text | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region; use `maxBytes` to cap long pages. |
+| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | text | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. |
+| `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | text or bytes | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. In the 0.4.0 wheel, the Python SDK doesn't request an inline image, so without `path` you get a plain size summary, not the image itself; always pass `path` for now. A later release is expected to return the image as `bytes` when `path` is omitted. |
+| `tree` | `url?`, `timeout?`, `backendNodeId?`, `maxDepth?` | text | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
+| `links` | `url?`, `timeout?` | JSON | Every visible link as `text`, `href` (resolved to an absolute URL), and `backendNodeId`. |
+| `node_details` (`nodeDetails`) | `backendNodeId` | JSON | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
+| `find_element` (`findElement`) | `role?`, `name?` | JSON | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
+| `interactive_elements` (`interactiveElements`) | `url?`, `timeout?` | JSON | Every interactive element on the page. |
+| `structured_data` (`structuredData`) | `url?`, `timeout?` | JSON | Structured data on the page, such as JSON-LD or OpenGraph tags. |
+| `detect_forms` (`detectForms`) | `url?`, `timeout?` | JSON | Forms on the page: fields, types, and required status. |
 
 ### Data extraction and scripting
 
-| Method | Arguments | Description |
-|---|---|---|
-| `extract` | `schema`, `save?` | Extract structured data from the current page using a schema mapping output field names to CSS-selector specs. |
-| `evaluate` | `script`, `url?`, `timeout?`, `save?` | Evaluate a JavaScript string in the page context and return its value. Runs in the page, so it cannot see your Python variables. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `extract` | `schema`, `save?` | JSON | Extract structured data from the current page using a schema mapping output field names to CSS-selector specs. |
+| `evaluate` | `script`, `url?`, `timeout?`, `save?` | typed | Evaluate a JavaScript string in the page context and return its value. Runs in the page, so it cannot see your Python variables. |
+
+**`evaluate`'s return** is typed like the JavaScript result: for example `1+1` comes back as the `int` `2`, and `({a:1})` comes back as the `dict` `{"a": 1}`.
 
 **`extract`'s `schema`** maps output field names to CSS-selector specs. Pass it as a Python `dict` or `list`, it's encoded for you; a JSON string also works:
 
@@ -121,43 +123,43 @@ Add `"limit": N` inside any array spec to cap matches. Every extracted value is 
 
 These methods dispatch real DOM events on the page:
 
-| Method | Arguments | Description |
-|---|---|---|
-| `click` | `selector` / `backendNodeId` | Click an interactive element. |
-| `fill` | `selector` / `backendNodeId`, `value` | Fill text into an input element. |
-| `scroll` | `backendNodeId?`, `x?`, `y?` | Scroll the page, or a specific element if `backendNodeId` is given. |
-| `hover` | `selector` / `backendNodeId` | Hover over an element, triggering `mouseover` and `mouseenter`. |
-| `press` | `key`, `selector?`, `backendNodeId?` | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
-| `select_option` (`selectOption`) | `selector` / `backendNodeId`, `value` | Select an option in a `<select>` element by its value. |
-| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked?` | Check or uncheck a checkbox or radio button. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `click` | `selector` / `backendNodeId` | text | Click an interactive element. |
+| `fill` | `selector` / `backendNodeId`, `value` | text | Fill text into an input element. |
+| `scroll` | `backendNodeId?`, `x?`, `y?` | text | Scroll the page, or a specific element if `backendNodeId` is given. |
+| `hover` | `selector` / `backendNodeId` | text | Hover over an element, triggering `mouseover` and `mouseenter`. |
+| `press` | `key`, `selector?`, `backendNodeId?` | text | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
+| `select_option` (`selectOption`) | `selector` / `backendNodeId`, `value` | text | Select an option in a `<select>` element by its value. |
+| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked` | text | Check or uncheck a checkbox or radio button. |
 
 ### Waiting
 
 These methods block until the page reaches a condition:
 
-| Method | Arguments | Description |
-|---|---|---|
-| `wait_for_selector` (`waitForSelector`) | `selector`, `timeout?` | Wait for an element matching a CSS selector to appear, and return its `backendNodeId`. |
-| `wait_for_script` (`waitForScript`) | `script`, `timeout?` | Wait until a JavaScript expression returns truthy, re-evaluated on every tick. |
-| `wait_for_state` (`waitForState`) | `state`, `timeout?` | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `wait_for_selector` (`waitForSelector`) | `selector`, `timeout?` | text | Wait for an element matching a CSS selector to appear, and return its `backendNodeId`. |
+| `wait_for_script` (`waitForScript`) | `script`, `timeout?` | text | Wait until a JavaScript expression returns truthy, re-evaluated on every tick. |
+| `wait_for_state` (`waitForState`) | `state`, `timeout?` | text | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
 
 ### State and debugging
 
-| Method | Arguments | Description |
-|---|---|---|
-| `get_url` (`getUrl`) | none | The URL currently loaded in the session. |
-| `get_cookies` (`getCookies`) | `url?`, `all?` | Cookies stored in the browser. Defaults to the current page's host; pass `url` for another host or `all=True` for every cookie. |
-| `get_env` (`getEnv`) | `name?` | With `name`, read one `LP_*` environment variable. Without it, list the `LP_*` names that are set. |
-| `console_logs` (`consoleLogs`) | none | Buffered `console.log`/`warn`/`error` messages since the last call, which then clears the buffer. |
+| Method | Arguments | Returns | Description |
+|---|---|---|---|
+| `get_url` (`getUrl`) | none | text | The URL currently loaded in the session. |
+| `get_cookies` (`getCookies`) | `url?`, `all?` | text | Cookies stored in the browser. Defaults to the current page's host; pass `url` for another host or `all=True` for every cookie. |
+| `get_env` (`getEnv`) | `name?` | text | With `name`, read one `LP_*` environment variable. Without it, list the `LP_*` names that are set. |
+| `console_logs` (`consoleLogs`) | none | text | Buffered `console.log`/`warn`/`error` messages since the last call, which then clears the buffer. |
 
 ## Script replay
 
-`run_script` and `run_script_async` replay a saved [PandaScript](/reference/pandascript) with no LLM call, by running `lightpanda run <script>` and returning its stdout. Installing the package also puts the `lightpanda` binary itself on `PATH`.
+`run_script` and `run_script_async` (its awaitable variant, run in a worker thread) replay a saved [PandaScript](/reference/pandascript) with no LLM call, by running `lightpanda run <script>` and returning its stdout. Installing the package also puts the `lightpanda` binary itself on `PATH`.
 
 ```python copy
 from lightpanda import run_script
 
-run_script("hn.lp.js", env={"LP_HN_USERNAME": "me"})
+run_script("hn.js", env={"LP_HN_USERNAME": "me"})
 ```
 
 | Argument | Default | Description |
@@ -167,7 +169,7 @@ run_script("hn.lp.js", env={"LP_HN_USERNAME": "me"})
 | `binary` | `None` | Same resolution as `Browser`'s `binary` argument. |
 | `timeout` | `None` | Seconds to wait for the process to exit. |
 
-A non-zero exit raises `ScriptError`. `run_script_async` is the awaitable variant, run in a worker thread.
+A non-zero exit raises `ScriptError`. Exceeding `timeout` raises `subprocess.TimeoutExpired` instead.
 
 ## Errors
 
@@ -176,4 +178,4 @@ A non-zero exit raises `ScriptError`. `run_script_async` is the awaitable varian
 | `LightpandaError` | Base class for every error the package raises. |
 | `ProtocolError` | The connection to the browser process failed: a malformed request, a timeout, or an internal error. Carries a `code` attribute. |
 | `ToolError` | A browser action reported failure, such as a bad selector, a JS exception inside `evaluate`, or a call on a closed session. |
-| `ScriptError` | `run_script` or `run_script_async` exited with a non-zero status. Carries `returncode`, `stdout`, and `stderr` attributes. |
+| `ScriptError` | `run_script` or `run_script_async` exited with a non-zero status, or the script file doesn't exist (`returncode=-1`). Carries `returncode`, `stdout`, and `stderr` attributes. |

--- a/src/content/reference/python.mdx
+++ b/src/content/reference/python.mdx
@@ -1,0 +1,179 @@
+---
+title: Python SDK
+description: Reference of the classes and methods in the Lightpanda Python package, covering every browser action and script replay.
+---
+import { Callout } from 'nextra/components'
+
+# Python SDK
+
+The [`lightpanda` package](https://pypi.org/project/lightpanda/) exposes `Browser`/`AsyncBrowser`, which spawn and manage the bundled binary, and `Session`/`AsyncSession`, with one method per browser action. See [Use the Python SDK](/guides/use-python) for practical documentation.
+
+## Browser
+
+`Browser()` spawns the bundled binary on first use. It is not fork-inheritable: create a fresh instance in a forked child.
+
+| Argument | Default | Description |
+|---|---|---|
+| `binary` | `None` | Path to a specific lightpanda binary. When omitted, resolved from the `LIGHTPANDA_BIN` environment variable, then the binary bundled in the package, then `PATH`. |
+| `env` | `None` | Extra environment variables for the spawned process. |
+| `timeout` | `300.0` | Seconds to wait for a response before raising `ProtocolError`. |
+| `verbose` | `False` | Print the spawned process's own logging. |
+| `args` | `()` | Extra CLI flags for the spawned process, for example `["--http-cache-dir", path]`. |
+
+| Method | Returns | Description |
+|---|---|---|
+| `new_session()` | `Session` | Open a new isolated browsing context: its own page, cookies, and memory. |
+| `tools` (property) | `dict[str, dict]` | Every available action, as `name → {description, schema}`, reported live by the running browser. |
+| `close()` | `None` | Stop the browser process. |
+
+`with Browser() as b:` calls `close()` on exit.
+
+## AsyncBrowser
+
+`AsyncBrowser` mirrors `Browser` for asyncio: every call runs on a browser-owned thread pool, so the event loop is never blocked.
+
+| Argument | Default | Description |
+|---|---|---|
+| `binary`, `env`, `timeout`, `verbose`, `args` | same as `Browser` | Forwarded to the underlying `Browser`. |
+| `max_concurrency` | `32` | Caps method calls executing concurrently across this browser's sessions. Worker threads are created lazily. |
+
+| Method | Returns | Description |
+|---|---|---|
+| `start()` | `AsyncBrowser` | Spawn the process and fetch its action list. Idempotent; called automatically on `async with` entry and by `new_session()`. |
+| `new_session()` | `AsyncSession` | Start the browser if needed, then open a new session. |
+| `session()` | async context manager | `async with browser.session() as page:` opens a session scoped to the block and closes it on exit. |
+| `tools` (property) | `dict[str, dict]` | Same as `Browser.tools`. |
+| `close()` | `None` | Stop the browser process, unless it was adopted with `wrap` (see below). |
+| `AsyncBrowser.wrap(browser, max_concurrency=32)` (classmethod) | `AsyncBrowser` | Adopt an already-running `Browser` for use from asyncio. `close()` then shuts down only the async facade, leaving the wrapped browser running. |
+
+`async with AsyncBrowser() as b:` calls `start()` on entry and `close()` on exit.
+
+## Session and AsyncSession
+
+`Browser.new_session()` and `AsyncBrowser.new_session()` are the only way to obtain a `Session` or `AsyncSession`; do not construct one directly.
+
+| Member | Description |
+|---|---|
+| `id` (property) | The session's id. |
+| `close()` | Close the session. Calls made after `close()` raise `ToolError`. |
+| `call(action, **kwargs)` | Invoke any action by name. The methods documented below route through this. |
+
+`with session:` (or `async with`) calls `close()` on exit, if you obtained the session outside a `with Browser()`/`with browser.session()` block that already closes it.
+
+## Calling an action
+
+Every browser action is a method on `Session`/`AsyncSession`, keyword-only. The original action name (`waitForSelector`) and a snake_case alias (`wait_for_selector`) both resolve to the same method: call whichever reads better in your code.
+
+<Callout type="warning">
+  Only the method name gets a snake_case alias; its keyword arguments keep their original names. `wait_for_selector(selector=..., timeout=...)` has no case change, but `click(selector=..., backendNodeId=...)`, `screenshot(fullPage=...)`, and `tree(maxDepth=...)` all keep a camelCase keyword even though the method itself is snake_case.
+</Callout>
+
+A method returns parsed JSON for JSON-carrying results (`extract`, `links`, `structured_data`, `detect_forms`, `interactive_elements`, `find_element`), and plain text for everything else, including `tree`'s indented outline and `get_cookies`' `name=value` lines. A failed action raises `ToolError`.
+
+In the Arguments column below, `?` marks an optional keyword argument, and `selector` / `backendNodeId` marks a pair where one of the two is required. Prefer `selector` for reproducibility; it also wins when you pass both. `backendNodeId` values come from a prior `tree`, `links`, or `find_element` call.
+
+### Navigation and search
+
+These methods bring a page into the browser:
+
+| Method | Arguments | Description |
+|---|---|---|
+| `goto` | `url`, `timeout?` | Navigate to a URL and load the page in memory so it can be reused later for info extraction. |
+| `search` | `query`, `timeout?` | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. The browser does not navigate; to open a result, call `goto` with its URL. |
+
+### Reading the page
+
+These methods read the loaded page without modifying it:
+
+| Method | Arguments | Description |
+|---|---|---|
+| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region; use `maxBytes` to cap long pages. |
+| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. |
+| `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. The Python SDK doesn't request an inline image, so always pass `path`; without it you get a plain size summary, not the image itself. |
+| `tree` | `url?`, `timeout?`, `backendNodeId?`, `maxDepth?` | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
+| `links` | `url?`, `timeout?` | Every visible link as `text`, `href` (resolved to an absolute URL), and `backendNodeId`. |
+| `node_details` (`nodeDetails`) | `backendNodeId` | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
+| `find_element` (`findElement`) | `role?`, `name?` | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
+| `interactive_elements` (`interactiveElements`) | `url?`, `timeout?` | Every interactive element on the page. |
+| `structured_data` (`structuredData`) | `url?`, `timeout?` | Structured data on the page, such as JSON-LD or OpenGraph tags. |
+| `detect_forms` (`detectForms`) | `url?`, `timeout?` | Forms on the page: fields, types, and required status. |
+
+### Data extraction and scripting
+
+| Method | Arguments | Description |
+|---|---|---|
+| `extract` | `schema`, `save?` | Extract structured data from the current page using a schema mapping output field names to CSS-selector specs. |
+| `evaluate` | `script`, `url?`, `timeout?`, `save?` | Evaluate a JavaScript string in the page context and return its value. Runs in the page, so it cannot see your Python variables. |
+
+**`extract`'s `schema`** maps output field names to CSS-selector specs. Pass it as a Python `dict` or `list`, it's encoded for you; a JSON string also works:
+
+| Schema value | Result |
+|---|---|
+| `"<sel>"` | First match's text, or `None` |
+| `["<sel>"]` | Every match's text |
+| `{"selector": "<sel>", "attr": "<name>"}` | First match's attribute (`href`/`src` resolve to absolute URLs) |
+| `[{"selector": "<sel>", "attr": "<name>"}]` | Every match's attribute |
+| `[{"selector": "<sel>", "fields": {...}}]` | One dict per match, with fields resolved relative to each match |
+
+Add `"limit": N` inside any array spec to cap matches. Every extracted value is a string or `None`; parse numbers yourself.
+
+### Interacting with the page
+
+These methods dispatch real DOM events on the page:
+
+| Method | Arguments | Description |
+|---|---|---|
+| `click` | `selector` / `backendNodeId` | Click an interactive element. |
+| `fill` | `selector` / `backendNodeId`, `value` | Fill text into an input element. |
+| `scroll` | `backendNodeId?`, `x?`, `y?` | Scroll the page, or a specific element if `backendNodeId` is given. |
+| `hover` | `selector` / `backendNodeId` | Hover over an element, triggering `mouseover` and `mouseenter`. |
+| `press` | `key`, `selector?`, `backendNodeId?` | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
+| `select_option` (`selectOption`) | `selector` / `backendNodeId`, `value` | Select an option in a `<select>` element by its value. |
+| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked?` | Check or uncheck a checkbox or radio button. |
+
+### Waiting
+
+These methods block until the page reaches a condition:
+
+| Method | Arguments | Description |
+|---|---|---|
+| `wait_for_selector` (`waitForSelector`) | `selector`, `timeout?` | Wait for an element matching a CSS selector to appear, and return its `backendNodeId`. |
+| `wait_for_script` (`waitForScript`) | `script`, `timeout?` | Wait until a JavaScript expression returns truthy, re-evaluated on every tick. |
+| `wait_for_state` (`waitForState`) | `state`, `timeout?` | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
+
+### State and debugging
+
+| Method | Arguments | Description |
+|---|---|---|
+| `get_url` (`getUrl`) | none | The URL currently loaded in the session. |
+| `get_cookies` (`getCookies`) | `url?`, `all?` | Cookies stored in the browser. Defaults to the current page's host; pass `url` for another host or `all=True` for every cookie. |
+| `get_env` (`getEnv`) | `name?` | With `name`, read one `LP_*` environment variable. Without it, list the `LP_*` names that are set. |
+| `console_logs` (`consoleLogs`) | none | Buffered `console.log`/`warn`/`error` messages since the last call, which then clears the buffer. |
+
+## Script replay
+
+`run_script` and `run_script_async` replay a saved [PandaScript](/reference/pandascript) with no LLM call, by running `lightpanda run <script>` and returning its stdout. Installing the package also puts the `lightpanda` binary itself on `PATH`.
+
+```python copy
+from lightpanda import run_script
+
+run_script("hn.lp.js", env={"LP_HN_USERNAME": "me"})
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `script` | required | Path to the script file. |
+| `env` | `None` | Extra environment variables for the child process, for example `LP_*` placeholder values the script reads. |
+| `binary` | `None` | Same resolution as `Browser`'s `binary` argument. |
+| `timeout` | `None` | Seconds to wait for the process to exit. |
+
+A non-zero exit raises `ScriptError`. `run_script_async` is the awaitable variant, run in a worker thread.
+
+## Errors
+
+| Error | Raised when |
+|---|---|
+| `LightpandaError` | Base class for every error the package raises. |
+| `ProtocolError` | The connection to the browser process failed: a malformed request, a timeout, or an internal error. Carries a `code` attribute. |
+| `ToolError` | A browser action reported failure, such as a bad selector, a JS exception inside `evaluate`, or a call on a closed session. |
+| `ScriptError` | `run_script` or `run_script_async` exited with a non-zero status. Carries `returncode`, `stdout`, and `stderr` attributes. |

--- a/src/content/reference/python.mdx
+++ b/src/content/reference/python.mdx
@@ -78,7 +78,7 @@ These methods bring a page into the browser:
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `goto` | `url`, `timeout?` | text | Navigate to a URL and load the page in memory so it can be reused later for info extraction. |
+| `goto` | `url`, `timeout?`, `waitUntil?` | text | Navigate to a URL and load the page in memory so it can be reused later for info extraction. `waitUntil` accepts the same states as `wait_for_state` and defaults to `load`. On the 0.4.0 wheel, `waitUntil` isn't yet a keyword; reach it with `page.call("goto", url=..., waitUntil=...)` until the next release. |
 | `search` | `query`, `timeout?` | text | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. The browser does not navigate; to open a result, call `goto` with its URL. |
 
 ### Reading the page
@@ -88,10 +88,10 @@ These methods read the loaded page without modifying it:
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
 | `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | text | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region; use `maxBytes` to cap long pages. |
-| `html` | `selector?`, `backendNodeId?`, `url?`, `timeout?` | text | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. |
+| `html` | `selector?`, `backendNodeId?`, `maxBytes?`, `strip?`, `url?`, `timeout?` | text | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. Use `maxBytes` to cap long pages. `strip` is an object of element groups to omit: `js` (script, noscript, script preloads), `css` (style, stylesheet links), `ui` (css plus img, picture, video, audio, svg, canvas, iframe) and `invisible` (elements set to display:none). `{"js": True, "css": True}` keeps a page dump small. On the 0.4.0 wheel, `maxBytes` and `strip` aren't yet keywords; reach them with `page.call("html", maxBytes=..., strip=...)` until the next release. |
 | `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | text or bytes | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. In the 0.4.0 wheel, the Python SDK doesn't request an inline image, so without `path` you get a plain size summary, not the image itself; always pass `path` for now. A later release is expected to return the image as `bytes` when `path` is omitted. |
 | `tree` | `url?`, `timeout?`, `backendNodeId?`, `maxDepth?` | text | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
-| `links` | `url?`, `timeout?` | JSON | Every visible link as `text`, `href` (resolved to an absolute URL), and `backendNodeId`. |
+| `links` | `limit?`, `url?`, `timeout?` | JSON | Extract all links as `text` (visible anchor text, falling back to aria-label/title/image alt), `href` (resolved URL), and `backendNodeId` (pass to `node_details`). One entry per href; hidden links are omitted. `limit` returns at most that many links, in document order. On the 0.4.0 wheel, `limit` isn't yet a keyword; reach it with `page.call("links", limit=...)` until the next release. |
 | `node_details` (`nodeDetails`) | `backendNodeId` | JSON | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
 | `find_element` (`findElement`) | `role?`, `name?` | JSON | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
 | `interactive_elements` (`interactiveElements`) | `url?`, `timeout?` | JSON | Every interactive element on the page. |
@@ -131,7 +131,7 @@ These methods dispatch real DOM events on the page:
 | `hover` | `selector` / `backendNodeId` | text | Hover over an element, triggering `mouseover` and `mouseenter`. |
 | `press` | `key`, `selector?`, `backendNodeId?` | text | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
 | `select_option` (`selectOption`) | `selector` / `backendNodeId`, `value` | text | Select an option in a `<select>` element by its value. |
-| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked` | text | Check or uncheck a checkbox or radio button. |
+| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked` | text | Check (`True`) or uncheck (`False`) a checkbox or radio button. Dispatches input, change, and click events. |
 
 ### Waiting
 


### PR DESCRIPTION
- New how-to guide: scrape a JS-rendered page with the `lightpanda` Python package, sync and async, with pagination and script replay
- New reference page: full `Browser`/`AsyncBrowser`/`Session` API, verified against a live `pip install lightpanda`