### PR TITLE
Rewrite the Hermes guide for Browser Use mode and Hermes v0.21.0

### DIFF
--- a/src/content/guides/use-hermes.mdx
+++ b/src/content/guides/use-hermes.mdx
@@ -3,100 +3,140 @@ title: Use Hermes Agent
 description: Run Hermes Agent with Lightpanda as the browser backend.
 ---
 
+import { Callout } from 'nextra/components'
+
 # Use Hermes Agent
 
-[Hermes Agent](https://hermes-agent.nousresearch.com) is an open source autonomous agent built by [Nous Research](https://nousresearch.com). It runs autonomously for long stretches, builds persistent memory, spawns subagents in parallel, and reaches you on Telegram, Discord, Slack, and other platforms while working on a remote VM. From version `v0.13.0`, Hermes has native support for Lightpanda as a browser backend.
+[Hermes Agent](https://hermes-agent.nousresearch.com) is an open source autonomous agent built by [Nous Research](https://nousresearch.com). It runs autonomously for long stretches, builds persistent memory, spawns subagents in parallel, and reaches you on Telegram, Discord, Slack, and other platforms while working on a remote VM.
 
-When configured to use Lightpanda, Hermes will route browser actions through Lightpanda, with automatic Chrome fallback for actions Lightpanda doesn't yet support (such as screenshots).
+Hermes has two browser drivers, and Lightpanda plugs into both:
+
+- **Browser Use mode** — the default since August 2026. The agent gets a single `browser_exec` tool that runs Python against a browser over CDP through the [Browser Use CLI](https://github.com/browser-use/browser-use).
+- **Built-in browser tools** (`browser_navigate`, `browser_snapshot`, …) — the older driver, which reaches browsers through [agent-browser](https://github.com/vercel-labs/agent-browser).
+
+Pick the section below that matches your driver. The setting is the same (`browser.engine: lightpanda`), what differs is what else has to be true for Hermes to honour it.
 
 ## Prerequisites
 
-- Hermes Agent `v0.13.0` or later
-- Lightpanda installed and on your `PATH`
+- Hermes Agent `v0.21.0` or later (`hermes update`, then `hermes --version`)
+- Lightpanda installed and on your `PATH` — check with `which lightpanda`
 
-If you don't yet have Lightpanda installed, follow the [installation guide](/run-locally/installation/one-liner).
+If you don't have Lightpanda yet, follow the [installation guide](/run-locally/installation/one-liner). Hermes and agent-browser also look in `~/.lightpanda/lightpanda` and `~/.local/bin/lightpanda`.
 
-## Install Hermes
+<Callout type="warning">
+  For the **built-in tools** path, use Lightpanda **0.3.7** until agent-browser ships [vercel-labs/agent-browser#1748](https://github.com/vercel-labs/agent-browser/pull/1748): nightly builds from 2026-08-27 onward reject the `--timeout` flag agent-browser still passes at launch, so Lightpanda never starts and every action silently falls back to Chrome. Browser Use mode is not affected.
+</Callout>
 
-If you don't have Hermes Agent yet, install it with the official one-liner:
+## Option A — Browser Use mode (the Hermes default)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-```
+Since Hermes `v0.21.0` ([NousResearch/hermes-agent#99312](https://github.com/NousResearch/hermes-agent/pull/99312)), Browser Use mode honours `browser.engine: lightpanda` natively: Hermes starts `lightpanda serve` itself, one process per session, and hands its endpoint to the Browser Use CLI for every `browser_exec` call. No Chromium, Playwright or Node.js is involved.
 
-If you already have Hermes installed, update to `v0.13.0` or later:
-
-```bash
-hermes update
-```
-
-Confirm the version:
-
-```bash
-hermes --version
-```
-
-## Configure Lightpanda as the browser backend
-
-Open Hermes' config file:
-
-```bash
-open ~/.hermes/config.yaml
-```
-
-Find the `browser:` block and add the `engine: lightpanda` line:
+Either pick **Lightpanda** in `hermes tools` → Browser Automation, or set it in `~/.hermes/config.yaml`:
 
 ```yaml
 browser:
+  cloud_provider: local
   engine: lightpanda
 ```
 
-Save and close the file.
+`cloud_provider: local` matters: `browser.engine` is the lowest-precedence browser setting in Hermes. It is ignored whenever a cloud provider is active — and on a setup that never picked a browser, any `BROWSERBASE_API_KEY`, `BROWSER_USE_API_KEY` or Nous subscription browser in `~/.hermes/.env` selects one automatically. A `browser.cdp_url` / `/browser connect` override takes precedence too. Since `v0.21.0`, `/browser status` and `hermes doctor` tell you when the engine is set but shadowed, and by what.
+
+<Callout type="info">
+  Lightpanda holds one page per CDP connection: the first `new_tab(url)` works, a second one fails with `TargetAlreadyLoaded` ([lightpanda-io/browser#1962](https://github.com/lightpanda-io/browser/issues/1962)). Hermes tells the agent to navigate with `goto_url(url)` after the first `new_tab`, and `capture_screenshot()` is unavailable — Lightpanda has no graphical renderer.
+</Callout>
+
+### Older Hermes: connect to a server you start yourself
+
+Before `v0.21.0`, Browser Use mode never reads `browser.engine`. On those versions, start Lightpanda's CDP server yourself:
+
+```bash
+lightpanda serve --host 127.0.0.1 --port 9222
+```
+
+Then point Hermes at it, either for the current session:
+
+```
+/browser connect ws://127.0.0.1:9222/
+```
+
+or permanently in `~/.hermes/config.yaml`:
+
+```yaml
+browser:
+  cdp_url: ws://127.0.0.1:9222/
+```
+
+## Option B — Built-in browser tools
+
+Switch Hermes off Browser Use mode and select Lightpanda as the local engine:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  backend: "off"
+  cloud_provider: local
+  engine: lightpanda
+```
+
+(`/browser use off` inside Hermes writes `backend: "off"` for you.)
+
+The same precedence rules as Option A apply (`cloud_provider: local`, no CDP override), plus one more: Camoufox (`CAMOFOX_URL`) also wins over `browser.engine` on this path.
+
+Hermes drives Lightpanda through `agent-browser --engine lightpanda` over CDP, the same way it drives local Chrome, with automatic Chrome fallback: Lightpanda handles navigate, snapshot, click, type, scroll, back, press and eval; screenshots, `browser_vision`, PDF generation, file uploads and anything that errors on Lightpanda are retried on Chrome.
+
+<Callout type="warning">
+  Before `v0.21.0`, on Ubuntu 23.10+, in Docker, or as root, Hermes injected Chromium sandbox flags (`--no-sandbox`) for every engine, and agent-browser rejects them under Lightpanda (`Custom Chrome arguments (--args) are not supported with Lightpanda`), so every action failed over to Chrome. Setting `AGENT_BROWSER_ARGS` yourself does not help. Fixed by [NousResearch/hermes-agent#81673](https://github.com/NousResearch/hermes-agent/pull/81673) (merged as #99460): run `hermes update`.
+</Callout>
 
 ## Verify the configuration
 
-Start Hermes:
+Start Hermes and run `/browser status`.
 
-```bash
-hermes
-```
-
-Run the `/browser` slash command:
+Option A shows the engine and the binary Hermes will spawn:
 
 ```
-/browser
+Engine: Lightpanda — Browser Use mode: Hermes spawns `lightpanda serve` per session
 ```
 
-You should see:
+If it instead reports `browser.engine is 'lightpanda' but it is NOT in use: …`, the message names what is shadowing it (a cloud provider, a CDP override, …); see the troubleshooting list below. On Hermes older than `v0.21.0`, after `/browser connect` you should see:
+
+```
+🌐 Browser connected to live Chromium-family browser via CDP
+   Endpoint: ws://127.0.0.1:9222
+```
+
+Option B shows the engine:
 
 ```
 🌐 Browser: local Lightpanda (agent-browser --engine lightpanda)
    ⚡ Lightpanda: faster navigation, no screenshot support
-   Automatic Chrome fallback for screenshots and failed commands
+   Automatic Chromium fallback for screenshots and failed commands
 ```
 
-Hermes will now route browser actions through Lightpanda.
-
-## Run a quick test
-
-Inside Hermes, try a prompt that involves browsing:
+Then try a prompt that involves browsing:
 
 ```
 Visit https://news.ycombinator.com and list the top 5 story titles.
 ```
 
-Hermes will spawn its browser tools and route them through Lightpanda. You'll see streaming tool calls (`browser_navigate`, `browser_snapshot`) executing against Lightpanda.
+To prove the engine rather than trust the status line, ask the agent for `navigator.userAgent`: Lightpanda reports `Lightpanda/1.0`.
 
-## Automatic Chrome fallback
+## Troubleshooting: Hermes uses Chrome even though I set the engine
 
-Lightpanda doesn't yet support every browser action Hermes might call. When Hermes invokes an unsupported action (e.g. screenshots), or when a command errors out on Lightpanda, Hermes transparently retries on Chrome.
+Check, in this order:
 
-This means enabling `engine: lightpanda` is non-disruptive: Lightpanda handles the actions it supports, Chrome handles the rest, and your agent's behavior remains unchanged.
-
-The current set of actions supported by Lightpanda inside Hermes covers the core agent workflow: navigate, snapshot, click, type, scroll, back, press, and eval. Actions that fall back to Chrome include screenshots, PDF generation, file uploads, and clipboard operations.
+1. **Which Hermes version?** Browser Use mode only reads `browser.engine` from `v0.21.0`; on older versions use `cdp_url` (see Option A). From `v0.21.0`, `/browser status` and `hermes doctor` say outright when the engine is shadowed.
+2. **Is a cloud provider selected?** `browser.cloud_provider` in `config.yaml`, or a cloud API key / Nous subscription browser on a never-configured setup. Set `cloud_provider: local`.
+3. **Is a CDP override active?** `browser.cdp_url` or a previous `/browser connect` (undo with `/browser disconnect`).
+4. **Is Camoufox selected?** Unset `CAMOFOX_URL`.
+5. **Linux sandbox flags** on Hermes older than `v0.21.0` (Option B, see the warning above).
+6. **Nightly `--timeout` rejection** (Option B, see Prerequisites): run `lightpanda serve --timeout 1` by hand; `FATAL app : unknown argument` means agent-browser cannot launch this build.
 
 ## Further reading
 
-- [Hermes Agent documentation](https://hermes-agent.nousresearch.com/docs/)
-- [Pull request that added Lightpanda support to Hermes](https://github.com/NousResearch/hermes-agent/pull/7144)
+- [Hermes browser documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/browser#lightpanda-local-engine)
+- [Hermes PR that added Lightpanda support](https://github.com/NousResearch/hermes-agent/pull/7144)
+- [Hermes PR adding Lightpanda to Browser Use mode](https://github.com/NousResearch/hermes-agent/pull/99312)
+- [Hermes PR isolating Lightpanda from Chromium flags](https://github.com/NousResearch/hermes-agent/pull/81673)
+- [Multi-target support in Lightpanda](https://github.com/lightpanda-io/browser/issues/1962)
 - [Lightpanda installation guide](/run-locally/installation/one-liner)

--- a/src/content/guides/use-hermes.mdx
+++ b/src/content/guides/use-hermes.mdx
@@ -24,12 +24,12 @@ Pick the section below that matches your driver. The setting is the same (`brows
 If you don't have Lightpanda yet, follow the [installation guide](/run-locally/installation/one-liner). Hermes and agent-browser also look in `~/.lightpanda/lightpanda` and `~/.local/bin/lightpanda`.
 
 <Callout type="warning">
-  For the **built-in tools** path, use Lightpanda **0.3.7** until agent-browser ships [vercel-labs/agent-browser#1748](https://github.com/vercel-labs/agent-browser/pull/1748): nightly builds from 2026-08-27 onward reject the `--timeout` flag agent-browser still passes at launch, so Lightpanda never starts and every action silently falls back to Chrome. Browser Use mode is not affected.
+  For the **built-in tools** path, use Lightpanda **0.3.7** until agent-browser ships its launcher fix: nightly builds from 2026-08-27 onward reject the `--timeout` flag agent-browser still passes at launch, so Lightpanda never starts and every action silently falls back to Chrome. Browser Use mode is not affected.
 </Callout>
 
 ## Option A — Browser Use mode (the Hermes default)
 
-Since Hermes `v0.21.0` ([NousResearch/hermes-agent#99312](https://github.com/NousResearch/hermes-agent/pull/99312)), Browser Use mode honours `browser.engine: lightpanda` natively: Hermes starts `lightpanda serve` itself, one process per session, and hands its endpoint to the Browser Use CLI for every `browser_exec` call. No Chromium, Playwright or Node.js is involved.
+Since Hermes `v0.21.0`, Browser Use mode honours `browser.engine: lightpanda` natively: Hermes starts `lightpanda serve` itself, one process per session, and hands its endpoint to the Browser Use CLI for every `browser_exec` call.
 
 Either pick **Lightpanda** in `hermes tools` → Browser Automation, or set it in `~/.hermes/config.yaml`:
 
@@ -42,29 +42,8 @@ browser:
 `cloud_provider: local` matters: `browser.engine` is the lowest-precedence browser setting in Hermes. It is ignored whenever a cloud provider is active — and on a setup that never picked a browser, any `BROWSERBASE_API_KEY`, `BROWSER_USE_API_KEY` or Nous subscription browser in `~/.hermes/.env` selects one automatically. A `browser.cdp_url` / `/browser connect` override takes precedence too. Since `v0.21.0`, `/browser status` and `hermes doctor` tell you when the engine is set but shadowed, and by what.
 
 <Callout type="info">
-  Lightpanda holds one page per CDP connection: the first `new_tab(url)` works, a second one fails with `TargetAlreadyLoaded` ([lightpanda-io/browser#1962](https://github.com/lightpanda-io/browser/issues/1962)). Hermes tells the agent to navigate with `goto_url(url)` after the first `new_tab`, and `capture_screenshot()` is unavailable — Lightpanda has no graphical renderer.
+  Lightpanda holds one page per CDP connection: the first `new_tab(url)` works, a second one fails with `TargetAlreadyLoaded`. Hermes tells the agent to navigate with `goto_url(url)` after the first `new_tab`, and `capture_screenshot()` is unavailable — Lightpanda has no graphical renderer.
 </Callout>
-
-### Older Hermes: connect to a server you start yourself
-
-Before `v0.21.0`, Browser Use mode never reads `browser.engine`. On those versions, start Lightpanda's CDP server yourself:
-
-```bash
-lightpanda serve --host 127.0.0.1 --port 9222
-```
-
-Then point Hermes at it, either for the current session:
-
-```
-/browser connect ws://127.0.0.1:9222/
-```
-
-or permanently in `~/.hermes/config.yaml`:
-
-```yaml
-browser:
-  cdp_url: ws://127.0.0.1:9222/
-```
 
 ## Option B — Built-in browser tools
 
@@ -85,7 +64,7 @@ The same precedence rules as Option A apply (`cloud_provider: local`, no CDP ove
 Hermes drives Lightpanda through `agent-browser --engine lightpanda` over CDP, the same way it drives local Chrome, with automatic Chrome fallback: Lightpanda handles navigate, snapshot, click, type, scroll, back, press and eval; screenshots, `browser_vision`, PDF generation, file uploads and anything that errors on Lightpanda are retried on Chrome.
 
 <Callout type="warning">
-  Before `v0.21.0`, on Ubuntu 23.10+, in Docker, or as root, Hermes injected Chromium sandbox flags (`--no-sandbox`) for every engine, and agent-browser rejects them under Lightpanda (`Custom Chrome arguments (--args) are not supported with Lightpanda`), so every action failed over to Chrome. Setting `AGENT_BROWSER_ARGS` yourself does not help. Fixed by [NousResearch/hermes-agent#81673](https://github.com/NousResearch/hermes-agent/pull/81673) (merged as #99460): run `hermes update`.
+  Before `v0.21.0`, on Ubuntu 23.10+, in Docker, or as root, Hermes injected Chromium sandbox flags (`--no-sandbox`) for every engine, and agent-browser rejects them under Lightpanda (`Custom Chrome arguments (--args) are not supported with Lightpanda`), so every action failed over to Chrome. Setting `AGENT_BROWSER_ARGS` yourself does not help; run `hermes update`.
 </Callout>
 
 ## Verify the configuration
@@ -98,12 +77,7 @@ Option A shows the engine and the binary Hermes will spawn:
 Engine: Lightpanda — Browser Use mode: Hermes spawns `lightpanda serve` per session
 ```
 
-If it instead reports `browser.engine is 'lightpanda' but it is NOT in use: …`, the message names what is shadowing it (a cloud provider, a CDP override, …); see the troubleshooting list below. On Hermes older than `v0.21.0`, after `/browser connect` you should see:
-
-```
-🌐 Browser connected to live Chromium-family browser via CDP
-   Endpoint: ws://127.0.0.1:9222
-```
+If it instead reports `browser.engine is 'lightpanda' but it is NOT in use: …`, the message names what is shadowing it (a cloud provider, a CDP override, …); see the troubleshooting list below.
 
 Option B shows the engine:
 
@@ -125,7 +99,7 @@ To prove the engine rather than trust the status line, ask the agent for `naviga
 
 Check, in this order:
 
-1. **Which Hermes version?** Browser Use mode only reads `browser.engine` from `v0.21.0`; on older versions use `cdp_url` (see Option A). From `v0.21.0`, `/browser status` and `hermes doctor` say outright when the engine is shadowed.
+1. **Is Hermes up to date?** Browser Use mode only reads `browser.engine` from `v0.21.0`; run `hermes update`. From there, `/browser status` and `hermes doctor` say outright when the engine is shadowed.
 2. **Is a cloud provider selected?** `browser.cloud_provider` in `config.yaml`, or a cloud API key / Nous subscription browser on a never-configured setup. Set `cloud_provider: local`.
 3. **Is a CDP override active?** `browser.cdp_url` or a previous `/browser connect` (undo with `/browser disconnect`).
 4. **Is Camoufox selected?** Unset `CAMOFOX_URL`.
@@ -135,8 +109,4 @@ Check, in this order:
 ## Further reading
 
 - [Hermes browser documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/browser#lightpanda-local-engine)
-- [Hermes PR that added Lightpanda support](https://github.com/NousResearch/hermes-agent/pull/7144)
-- [Hermes PR adding Lightpanda to Browser Use mode](https://github.com/NousResearch/hermes-agent/pull/99312)
-- [Hermes PR isolating Lightpanda from Chromium flags](https://github.com/NousResearch/hermes-agent/pull/81673)
-- [Multi-target support in Lightpanda](https://github.com/lightpanda-io/browser/issues/1962)
 - [Lightpanda installation guide](/run-locally/installation/one-liner)


### PR DESCRIPTION
## What

Rewrites `guides/use-hermes` for the current state of Hermes Agent.

- Hermes' default browser driver is now **Browser Use mode**, where the previously documented `engine: lightpanda` one-liner was a silent no-op. The guide now covers both drivers (Browser Use mode and the built-in `browser_*` tools) as Option A / Option B.
- Documents the native Lightpanda support in Browser Use mode that shipped in Hermes v0.21.0 (NousResearch/hermes-agent#99312): `cloud_provider: local` + `engine: lightpanda`, or the **Lightpanda** row in `hermes tools`. Keeps the manual `lightpanda serve` + `cdp_url` setup as the fallback for older Hermes.
- Explains the precedence rules that shadow `browser.engine` (cloud providers auto-selected from stray API keys, CDP overrides, Camoufox) and the new `/browser status` / `hermes doctor` shadowing notice.
- Notes the Linux sandbox-flag fallback bug fixed in v0.21.0 (NousResearch/hermes-agent#81673) and the agent-browser `--timeout` launch failure on recent Lightpanda nightlies (vercel-labs/agent-browser#1748, still open, so the built-in tools path pins Lightpanda 0.3.7 for now).
- Adds the one-page-per-connection caveat (lightpanda-io/browser#1962) and a "Hermes uses Chrome even though I set the engine" troubleshooting list.