### PR TITLE
Upgrade Biome to 2.5.11 and make CI actually run it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: 2.5.11
       - name: Lint
-        run: yarn biome-lint
+        run: biome ci . --diagnostic-level=error

--- a/biome.json
+++ b/biome.json
@@ -1,15 +1,27 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
   "files": {
-    "ignore": ["package.json", "node_modules", ".next", ".pnp.cjs", ".pnp.loader.mjs", "out"]
+    "includes": [
+      "**",
+      "!**/package.json",
+      "!**/node_modules",
+      "!**/.next",
+      "!**/.pnp.cjs",
+      "!**/.pnp.loader.mjs",
+      "!**/out"
+    ]
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noArrayIndexKey": "warn"
@@ -42,6 +54,11 @@
       "semicolons": "asNeeded",
       "trailingCommas": "all",
       "arrowParentheses": "asNeeded"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "NODE_ENV='production' next build",
     "postbuild": "pagefind --site ./out --output-path ./out/_pagefind && node scripts/generate-redirects.mjs",
     "typecheck": "npx -p typescript tsc --noEmit",
-    "lint": "next lint && yarn dlx biome ci . --diagnostic-level=error",
-    "biome-lint": "npx biome ci . --diagnostic-level=error",
+    "lint": "next lint && biome ci . --diagnostic-level=error",
+    "biome-lint": "biome ci . --diagnostic-level=error",
     "lint-apply": "next lint --fix && biome check . --write",
     "start": "next start -p 1414"
   },
@@ -31,7 +31,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "2.5.11",
     "@tailwindcss/postcss": "^4.0.17",
     "autoprefixer": "^10.4.21",
     "pagefind": "^1.3.0",

--- a/scripts/generate-redirects.mjs
+++ b/scripts/generate-redirects.mjs
@@ -15,7 +15,7 @@ const outDir = join(root, 'out')
 // A target that already carries its own fragment (e.g. `#serve`) must not
 // also inherit the visitor's `location.hash`, or the two concatenate into an
 // invalid double-fragment URL.
-const stub = (href) => `<!doctype html>
+const stub = href => `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/src/app/[[...mdxPath]]/page.tsx
+++ b/src/app/[[...mdxPath]]/page.tsx
@@ -1,8 +1,8 @@
 import { siteDetails } from '@lightpanda/common/data/siteDetails'
 import type { Metadata } from 'next'
 import { generateStaticParamsFor, importPage } from 'nextra/pages'
-import { useMDXComponents as getMDXComponents } from '../../mdx-components'
 import { DocsAutoJsonLd } from '@/components/lightpanda/DocsAutoJsonLd'
+import { useMDXComponents as getMDXComponents } from '../../mdx-components'
 
 type PageProps = {
   params: Promise<{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,9 @@
+import { DNSPrefetch } from '@lightpanda/common/components/DNSPrefetch'
+import { Favicon } from '@lightpanda/common/components/Favicon'
 import { Fira_Code, Fira_Sans } from 'next/font/google'
 import { Head as NextraHead } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
-
 import { DocsClientLayout } from '@/components/lightpanda/DocsClientLayout'
-import { DNSPrefetch } from '@lightpanda/common/components/DNSPrefetch'
-import { Favicon } from '@lightpanda/common/components/Favicon'
 
 import 'nextra-theme-docs/style.css'
 import '@lightpanda/common/styles/variables.css'
@@ -40,12 +39,16 @@ export default async function RootLayout({
           lightness: 65,
         }}
       >
-        <style dangerouslySetInnerHTML={{ __html: `
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
           :root {
             --main-font: ${firaSans.style.fontFamily}, sans-serif;
             --code-font: ${firaCode.style.fontFamily}, sans-serif;
           }
-        ` }} />
+        `,
+          }}
+        />
         <Favicon />
         <DNSPrefetch />
         <link rel="alternate" type="text/markdown" href="/llms.txt" />
@@ -57,7 +60,8 @@ export default async function RootLayout({
               '@type': 'WebSite',
               name: 'Lightpanda Documentation',
               url: 'https://lightpanda.io/docs',
-              description: 'Official documentation for Lightpanda headless browser — installation, quickstart guides, API reference, and cloud deployment.',
+              description:
+                'Official documentation for Lightpanda headless browser — installation, quickstart guides, API reference, and cloud deployment.',
               about: { '@id': 'https://lightpanda.io/#software' },
               publisher: {
                 '@type': 'Organization',
@@ -73,9 +77,7 @@ export default async function RootLayout({
         />
       </NextraHead>
       <body data-pagefind-body>
-        <DocsClientLayout pageMap={pageMap}>
-          {children}
-        </DocsClientLayout>
+        <DocsClientLayout pageMap={pageMap}>{children}</DocsClientLayout>
       </body>
     </html>
   )

--- a/src/components/lightpanda/DocsAutoJsonLd.tsx
+++ b/src/components/lightpanda/DocsAutoJsonLd.tsx
@@ -12,15 +12,11 @@ interface DocsAutoJsonLdProps {
 }
 
 // Paths that indicate a guide/tutorial page (HowTo schema)
-const GUIDE_PATTERNS = [
-  'quickstart/',
-  'guides/',
-  'getting-started',
-]
+const GUIDE_PATTERNS = ['quickstart/', 'guides/', 'getting-started']
 
 function isGuidePage(filePath: string): boolean {
   const normalized = filePath.replace('src/content/', '')
-  return GUIDE_PATTERNS.some((pattern) => normalized.includes(pattern))
+  return GUIDE_PATTERNS.some(pattern => normalized.includes(pattern))
 }
 
 function filePathToDocsPath(filePath: string): string {

--- a/src/components/lightpanda/DocsClientLayout.tsx
+++ b/src/components/lightpanda/DocsClientLayout.tsx
@@ -1,15 +1,14 @@
 'use client'
 
-import { type ReactNode } from 'react'
-import { Layout } from 'nextra-theme-docs'
-
-import { Canonical } from '@/components/lightpanda/Canonical'
-import { Footer } from '@/components/lightpanda/Footer'
-import { Navbar } from '@/components/lightpanda/Navbar'
 import { Providers } from '@lightpanda/common/components/Providers'
 import { SocialIcons } from '@lightpanda/common/components/SocialIcons'
 import { Version } from '@lightpanda/common/components/Version'
 import { siteDetails } from '@lightpanda/common/data/siteDetails'
+import { Layout } from 'nextra-theme-docs'
+import type { ReactNode } from 'react'
+import { Canonical } from '@/components/lightpanda/Canonical'
+import { Footer } from '@/components/lightpanda/Footer'
+import { Navbar } from '@/components/lightpanda/Navbar'
 
 type DocsClientLayoutProps = {
   children: ReactNode

--- a/src/mdx-components.ts
+++ b/src/mdx-components.ts
@@ -1,5 +1,5 @@
-import { createElement, type ReactNode } from 'react'
 import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs'
+import { createElement, type ReactNode } from 'react'
 
 type MDXComponentsProps = {
   components?: Readonly<unknown>
@@ -24,8 +24,8 @@ export function useMDXComponents(props: MDXComponentsProps) {
       [key: string]: unknown
     }) {
       return ThemeWrapper
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ? createElement(ThemeWrapper, { metadata, ...rest } as any, children)
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          createElement(ThemeWrapper, { metadata, ...rest } as any, children)
         : createElement('div', null, children)
     },
   }


### PR DESCRIPTION
## What

- **CI was a no-op.** `npx biome ci .` resolves the unrelated [`biome`](https://www.npmjs.com/package/biome) npm package (an env-var manager), not `@biomejs/biome`, so the lint job passed in seconds without linting anything. The workflow now installs Biome through `biomejs/setup-biome` and runs `biome ci .` directly.
- Pin `@biomejs/biome` to `2.5.11` (exact, as Biome recommends) and drop the `npx` / `yarn dlx` indirection from the package scripts.
- Migrate `biome.json` to the 2.x schema with `biome migrate` (`files.ignore` → `files.includes`, `organizeImports` → `assist`).
- Biome 2 parses CSS, so enable `css.parser.tailwindDirectives` for the `@apply` / `@tailwind` rules in `src/styles` and `globals.css`. The CSS files needed no reformatting.
- Apply the fixes `biome check --write` reports on the existing sources: import ordering, `import type`, and formatting in six files. No behaviour changes.

`biome ci . --diagnostic-level=error` is clean on this branch.