### PR TITLE
Document WebDriver BiDi and add Python to the Playwright CDP page

### DIFF
--- a/src/content/core-concepts/architecture-overview.mdx
+++ b/src/content/core-concepts/architecture-overview.mdx
@@ -17,7 +17,7 @@ A normal browser runs a rendering pipeline to turn a page into pixels for a huma
 
 Lightpanda drops the rendering pipeline. What remains is the set of components automation uses, the same ones detailed further down this page:
 
-- **Control surface.** The entry points you drive it through: `fetch`, `serve` (CDP), `agent`, `mcp`, and, on the cloud, the HTTP API.
+- **Control surface.** The entry points you drive it through: `fetch`, `serve` (CDP or WebDriver BiDi), `agent`, `mcp`, and, on the cloud, the HTTP API.
 - **Network layer.** Fetches the main document and its subresources over HTTP.
 - **HTML parser.** Turns fetched HTML into that DOM.
 - **JavaScript engine.** Runs the page's scripts. Lightpanda uses V8, the same engine as Chrome.
@@ -55,7 +55,7 @@ Every box in the diagram maps to a directory in the [browser repository](https:/
 The same engine runs behind these entry points. Each is a different way to drive it, and each has different availability across [local and cloud](/core-concepts/local-vs-cloud#feature-coverage):
 
 - [`fetch`](/run-locally/commands#fetch) loads one or more URLs and dumps the result to stdout as HTML or Markdown. It is a one-shot command with no server.
-- [`serve`](/run-locally/commands#serve) starts a CDP server on port `9222` by default. Clients like [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) connect over the Chrome DevTools Protocol. This is the mode most automation uses.
+- [`serve`](/run-locally/commands#serve) starts a CDP server on port `9222` by default. Clients like [Puppeteer](/usage/cdp/puppeteer), [Playwright](/usage/cdp/playwright), and [chromedp](/usage/cdp/chromedp) connect over the Chrome DevTools Protocol. This is the mode most automation uses. Pass `--protocol webdriver` to speak [WebDriver BiDi](/usage/bidi/selenium) instead.
 - [`agent`](/usage/agent) starts an interactive AI agent that browses the web from natural language and can record reproducible scripts.
 - [`mcp`](/usage/mcp) starts a Model Context Protocol server over stdio, so an LLM host can use the browser as a tool.
 - The [HTTP API](/usage/api) is a `POST /api/fetch` endpoint that returns a page's HTML or Markdown from a single request, no CDP script needed. It is the cloud's equivalent of the local `fetch` command.

--- a/src/content/core-concepts/local-vs-cloud.mdx
+++ b/src/content/core-concepts/local-vs-cloud.mdx
@@ -11,7 +11,13 @@ Lightpanda runs the same engine two ways. You can run the binary yourself, on yo
 
 ## Choose local or cloud
 
-**Run local when** you want full control and want nothing to leave your machine. The binary runs on your hardware, so pages you visit and data you extract stay in your infrastructure. Local gives you every interface: the [CDP server](/run-locally/commands#serve), the [MCP server](/usage/mcp) with all tools, and the built-in [AI agent](/usage/agent). You manage the process, the scaling, and the network egress yourself.
+**Run local when** you want full control and want nothing to leave your machine. The binary runs on your hardware, so pages you visit and data you extract stay in your infrastructure. Local gives you every interface:
+
+- The [CDP](/run-locally/commands#serve) or the [WebDriver BiDi](/usage/bidi/selenium) server
+- The [MCP server](/usage/mcp), with all tools
+- The built-in [AI agent](/usage/agent)
+
+You manage the process, the scaling, and the network egress yourself.
 
 **Use the cloud when** you do not want to run or scale browsers. You sign up, get a token, and connect a remote browser with no process to manage and no host to keep alive. Lightpanda Cloud runs the browser on its servers and adds the parts a hosted service needs: a [console](https://console.lightpanda.io) to manage your account and tokens and review recent sessions, usage-based plans with concurrency and monthly limits, a managed proxy pool that helps when a target blocks datacenter IPs, and an [HTTP API](/usage/api) that returns a page's HTML or Markdown from a single request with no CDP script. Because requests run on Lightpanda's servers, your target URLs and the fetched content pass through Lightpanda's infrastructure.
 

--- a/src/content/core-concepts/what-is-lightpanda.mdx
+++ b/src/content/core-concepts/what-is-lightpanda.mdx
@@ -19,7 +19,7 @@ Lightpanda drops the graphical rendering engine entirely and rebuilds the rest a
 
 Lightpanda meets you at the interface you already use:
 
-- **CDP**: [Puppeteer](https://pptr.dev/), [Playwright](https://playwright.dev/), and [Chromedp](https://github.com/chromedp/chromedp) connect to it the same way they connect to Chrome. Point the client at Lightpanda's endpoint and keep your existing scripts.
+- **CDP or WebDriver BiDi**: [Puppeteer](https://pptr.dev/), [Playwright](https://playwright.dev/), and [Chromedp](https://github.com/chromedp/chromedp) connect over CDP the same way they connect to Chrome. [Selenium](/usage/bidi/selenium) drives it over the W3C WebDriver BiDi standard instead, and so does [Puppeteer](/usage/bidi/puppeteer). Point the client at Lightpanda's endpoint and keep your existing scripts.
 - **MCP**: control the browser from AI applications over the [Model Context Protocol](https://modelcontextprotocol.io).
 - **HTTP API**: retrieve results directly over HTTP, without writing or running a CDP script.
 

--- a/src/content/guides/use-python.mdx
+++ b/src/content/guides/use-python.mdx
@@ -8,7 +8,7 @@ import { Callout, Tabs } from 'nextra/components'
 
 In this guide, you'll scrape a JavaScript-rendered page with the [`lightpanda` Python package](https://pypi.org/project/lightpanda/) and extract structured data from it with `page.extract`.
 
-The package bundles the Lightpanda browser binary, so there's no CDP client to wire up and no separate browser download, unlike driving Lightpanda from [Puppeteer or Playwright](/guides/retrieve-an-html-webpage). It also uses [an order of magnitude less memory than a Selenium and Chrome stack](https://github.com/lightpanda-io/lightpanda-python/blob/main/examples/compare.py) for the same scrape.
+The package bundles the Lightpanda browser binary, so there's no client to wire up and no separate browser download, unlike driving Lightpanda from [Playwright](/usage/cdp/playwright) or [Selenium](/usage/bidi/selenium). It also uses [an order of magnitude less memory than a Selenium and Chrome stack](https://github.com/lightpanda-io/lightpanda-python/blob/main/examples/compare.py) for the same scrape.
 
 ## Prerequisites
 

--- a/src/content/run-locally/commands.mdx
+++ b/src/content/run-locally/commands.mdx
@@ -25,7 +25,7 @@ Choose the output format with `--dump` and control how long the page runs with t
 
 ## Serve
 
-Start Lightpanda as a [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) server to control it with clients like [Puppeteer](https://pptr.dev/), [Playwright](https://playwright.dev/) or [Chromedp](https://github.com/chromedp/chromedp).
+Start Lightpanda as a server for automation clients. By default it speaks [CDP](https://chromedevtools.github.io/devtools-protocol/) (Chrome DevTools Protocol). Pass `--protocol webdriver` to speak [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) instead, or both flags to serve them on the same port.
 
 ```sh copy
 lightpanda serve --obey-robots
@@ -41,6 +41,11 @@ Find all options in the [serve command reference](/reference/cli/serve#options).
 - [Puppeteer](/usage/cdp/puppeteer)
 - [Playwright](/usage/cdp/playwright)
 - [Chromedp](/usage/cdp/chromedp)
+
+**Connect a BiDi client**, after adding `--protocol webdriver`:
+
+- [Puppeteer](/usage/bidi/puppeteer)
+- [Selenium](/usage/bidi/selenium)
 
 ## MCP
 

--- a/src/content/usage/_meta.ts
+++ b/src/content/usage/_meta.ts
@@ -7,6 +7,12 @@ const meta: MetaRecord = {
       collapsed: true,
     },
   },
+  bidi: {
+    title: 'BiDi',
+    theme: {
+      collapsed: true,
+    },
+  },
   agent: 'Agent',
   pandascript: 'PandaScript',
   mcp: 'MCP',

--- a/src/content/usage/bidi/_meta.ts
+++ b/src/content/usage/bidi/_meta.ts
@@ -1,0 +1,8 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  puppeteer: 'Puppeteer',
+  selenium: 'Selenium',
+}
+
+export default meta

--- a/src/content/usage/bidi/puppeteer.mdx
+++ b/src/content/usage/bidi/puppeteer.mdx
@@ -1,0 +1,46 @@
+---
+title: Puppeteer (BiDi)
+description: Use Lightpanda with Puppeteer over the WebDriver BiDi protocol instead of CDP.
+---
+import { Callout } from 'nextra/components'
+
+# Puppeteer (BiDi)
+
+Use Lightpanda with [Puppeteer](https://pptr.dev/) over [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) instead of the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP). Puppeteer's public API is the same either way; only the connection changes.
+
+More examples in [demo/puppeteer/bidi](https://github.com/lightpanda-io/demo/tree/main/puppeteer/bidi).
+
+<Callout type="warning">
+  BiDi support is new and covers less than CDP: only `browsingContext` and a subset of `script` are implemented. `page.waitForSelector`, `page.waitForFunction`, and `page.click(selector)` don't work as a result. See the demo above for the polling and coordinate-click workarounds.
+</Callout>
+
+Start Lightpanda with the `webdriver` protocol enabled (find all options in the [serve command reference](/reference/cli/serve#options)):
+
+```sh copy
+lightpanda serve --host 127.0.0.1 --port 9222 --protocol webdriver
+```
+
+Connect Puppeteer to the `/session` path with `protocol: 'webDriverBiDi'`:
+
+```js copy
+'use strict'
+
+import puppeteer from 'puppeteer-core'
+
+const browser = await puppeteer.connect({
+  browserWSEndpoint: 'ws://127.0.0.1:9222/session',
+  protocol: 'webDriverBiDi',
+})
+
+const context = await browser.createBrowserContext()
+const page = await context.newPage()
+
+await page.goto('https://wikipedia.com/', { waitUntil: 'load' })
+
+const title = await page.title()
+console.log(title)
+
+await page.close()
+await context.close()
+await browser.disconnect()
+```

--- a/src/content/usage/bidi/selenium.mdx
+++ b/src/content/usage/bidi/selenium.mdx
@@ -1,0 +1,100 @@
+---
+title: Selenium (BiDi)
+description: Use Lightpanda with Selenium over the WebDriver BiDi protocol, in JavaScript or Python.
+---
+import { Tabs, Callout } from 'nextra/components'
+
+# Selenium (BiDi)
+
+Use Lightpanda with [Selenium](https://www.selenium.dev/) over [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/). Lightpanda only implements the BiDi handshake of the classic WebDriver protocol, not full classic automation, so a session is created the normal Selenium way but driven with BiDi commands (`browsingContext`, `script`) instead of `driver.get()` or `driver.findElement()`.
+
+<Callout type="warning">
+  BiDi support is new and covers less than CDP: only `browsingContext` and a subset of `script` are implemented.
+</Callout>
+
+Start Lightpanda with the `webdriver` protocol enabled (find all options in the [serve command reference](/reference/cli/serve#options)):
+
+```sh copy
+lightpanda serve --host 127.0.0.1 --port 9222 --protocol webdriver
+```
+
+Request a BiDi session by setting the `webSocketUrl` capability to `true` (`browserName` can be any value; Lightpanda reports itself back regardless), then drive it with BiDi commands:
+
+<Tabs items={['JavaScript', 'Python']} className="-mb-4">
+  <Tabs.Tab id="javascript" className="m-0">
+```sh copy
+npm install selenium-webdriver
+```
+
+```js copy
+'use strict'
+
+import { Builder, Capabilities } from 'selenium-webdriver'
+import { BrowsingContext } from 'selenium-webdriver/bidi/generated/browsing_context.js'
+import { Script } from 'selenium-webdriver/bidi/generated/script.js'
+
+const caps = new Capabilities()
+caps.set('browserName', 'lightpanda')
+caps.set('webSocketUrl', true)
+
+const driver = await new Builder()
+  .usingServer('http://127.0.0.1:9222')
+  .withCapabilities(caps)
+  .build()
+
+const bidi = await driver.getBidi()
+await bidi.waitForConnection()
+
+const browsingContext = new BrowsingContext(bidi)
+const script = new Script(bidi)
+
+const { context } = await browsingContext.create({ type: 'tab' })
+await browsingContext.navigate({ context, url: 'https://wikipedia.com/', wait: 'complete' })
+
+const title = await script.evaluate({
+  expression: 'document.title',
+  target: { context },
+  awaitPromise: false,
+})
+console.log(title.result.value)
+
+await browsingContext.close({ context })
+await driver.quit()
+```
+  </Tabs.Tab>
+  <Tabs.Tab id="python" className="m-0">
+```sh copy
+pip install selenium
+```
+
+```python copy
+import os
+
+from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.common.bidi.common import command_builder
+from selenium.webdriver.remote.webdriver import WebDriver
+
+options = ArgOptions()
+options.set_capability("browserName", "lightpanda")
+options.set_capability("webSocketUrl", True)
+
+driver = WebDriver(command_executor="http://127.0.0.1:9222", options=options)
+
+context = driver.browsing_context.create(type="tab")
+driver.browsing_context.navigate(context=context, url="https://wikipedia.com/", wait="complete")
+
+# driver.script doesn't expose evaluate yet, so build the BiDi command directly.
+result = driver.browsing_context.conn.execute(command_builder(
+    "script.evaluate",
+    {"expression": "document.title", "target": {"context": context}, "awaitPromise": False},
+))
+print(result["result"]["value"])
+
+driver.browsing_context.close(context)
+driver.quit()
+
+# Selenium's BiDi thread outlives quit(); force the process to exit instead.
+os._exit(0)
+```
+  </Tabs.Tab>
+</Tabs>

--- a/src/content/usage/bidi/selenium.mdx
+++ b/src/content/usage/bidi/selenium.mdx
@@ -84,7 +84,7 @@ context = driver.browsing_context.create(type="tab")
 driver.browsing_context.navigate(context=context, url="https://wikipedia.com/", wait="complete")
 
 # driver.script doesn't expose evaluate yet, so build the BiDi command directly.
-result = driver.browsing_context.conn.execute(command_builder(
+result = driver.browsing_context._conn.execute(command_builder(
     "script.evaluate",
     {"expression": "document.title", "target": {"context": context}, "awaitPromise": False},
 ))

--- a/src/content/usage/cdp/playwright.mdx
+++ b/src/content/usage/cdp/playwright.mdx
@@ -6,9 +6,9 @@ import { Tabs } from 'nextra/components'
 
 # Playwright
 
-Use Lightpanda with [Playwright](https://playwright.dev/) via the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP).
+Use Lightpanda with [Playwright](https://playwright.dev/) via the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP), in JavaScript or Python.
 
-More examples in [demo/playwright](https://github.com/lightpanda-io/demo/tree/main/playwright).
+More examples in [demo/playwright](https://github.com/lightpanda-io/demo/tree/main/playwright) (JavaScript).
 
 <Tabs items={['Local', 'Cloud']}>
   <Tabs.Tab>
@@ -18,8 +18,10 @@ Start Lightpanda as a local CDP server (find all options in the [serve command r
 lightpanda serve --host 127.0.0.1 --port 9222
 ```
 
-Connect Playwright using `chromium.connectOverCDP`:
+Connect Playwright:
 
+<Tabs items={['JavaScript', 'Python']} className="-mb-4">
+  <Tabs.Tab id="javascript" className="m-0">
 ```js copy
 import { chromium } from 'playwright-core';
 
@@ -38,13 +40,42 @@ await context.close();
 await browser.close();
 ```
   </Tabs.Tab>
+  <Tabs.Tab id="python" className="m-0">
+Install the [`playwright` package](https://pypi.org/project/playwright/):
+
+```sh copy
+pip install playwright
+```
+
+```python copy
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp("ws://127.0.0.1:9222")
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("https://wikipedia.com/")
+
+    title = page.title()
+    print(title)
+
+    page.close()
+    context.close()
+    browser.close()
+```
+  </Tabs.Tab>
+</Tabs>
+  </Tabs.Tab>
   <Tabs.Tab>
-Export your API token and connect to the cloud endpoint:
+Set your API token and connect to the cloud endpoint. The connection uses `wss://` (WebSocket over TLS) instead of the local `ws://`:
 
 ```sh copy
 export LPD_TOKEN="your token here"
 ```
 
+<Tabs items={['JavaScript', 'Python']} className="-mb-4">
+  <Tabs.Tab id="javascript" className="m-0">
 ```js copy
 import playwright from "playwright-core";
 
@@ -60,8 +91,29 @@ await page.close();
 await context.close();
 await browser.close();
 ```
+  </Tabs.Tab>
+  <Tabs.Tab id="python" className="m-0">
+```python copy
+import os
+from playwright.sync_api import sync_playwright
 
-In the [playground](/run-on-lightpanda-cloud/playground), the console builds this URL for you and exposes it as `CDP_WS_URL`. Pass `process.env.CDP_WS_URL` to `connectOverCDP` there, since `LPD_TOKEN` does not exist in that runtime.
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(
+        "wss://euwest.cloud.lightpanda.io/ws?token=" + os.environ["LPD_TOKEN"]
+    )
+    context = browser.new_context()
+    page = context.new_page()
+
+    # ...
+
+    page.close()
+    context.close()
+    browser.close()
+```
+  </Tabs.Tab>
+</Tabs>
+
+In the [playground](/run-on-lightpanda-cloud/playground), the console builds this URL for you and exposes it as `CDP_WS_URL`. Use `process.env.CDP_WS_URL` (JavaScript) or `os.environ["CDP_WS_URL"]` (Python) there, since `LPD_TOKEN` does not exist in that runtime.
 
 ## Cloud options
 


### PR DESCRIPTION
- Add WebDriver BiDi docs: `usage/bidi/puppeteer` and `usage/bidi/selenium` (JS + Python), plus a `--protocol webdriver` mention in `run-locally/commands` and core concepts pages
- Add a Python tab to `usage/cdp/playwright` (via Playwright's official Python binding)
- Point the Python guide's client comparison at Playwright and Selenium instead of the JS-only guide