### PR TITLE
Python SDK docs: snake_case names and generated API reference link

### DIFF
--- a/src/content/guides/use-python.mdx
+++ b/src/content/guides/use-python.mdx
@@ -161,10 +161,10 @@ asyncio.run(main())
 ```
 
 <Callout type="info" emoji="ℹ️">
-  Every browser method is available as a `Session` method, in both camelCase and snake_case (`waitForSelector` and `wait_for_selector` both work), typed and documented in your IDE.
+  Every browser action is a `Session` method, typed and documented in your IDE, with the action and its arguments in snake_case (`wait_for_selector`, `backend_node_id`).
 </Callout>
 
-Find every method's arguments in the [Python SDK reference](/reference/python).
+Find every method's arguments in the [Python SDK reference](/reference/python), or browse the generated API reference at [lightpanda.io/lightpanda-python](https://lightpanda.io/lightpanda-python/).
 
 ## Replay a saved script
 

--- a/src/content/reference/python.mdx
+++ b/src/content/reference/python.mdx
@@ -2,7 +2,6 @@
 title: Python SDK
 description: Reference of the classes and methods in the Lightpanda Python package, covering every browser action and script replay.
 ---
-import { Callout } from 'nextra/components'
 
 # Python SDK
 
@@ -56,21 +55,17 @@ The [`lightpanda` package](https://pypi.org/project/lightpanda/) exposes `Browse
 |---|---|
 | `id` (property) | The session's id. |
 | `close()` | Close the session. Calls made after `close()` raise `ToolError`. |
-| `call(action, **kwargs)` | Invoke any action by name. The methods documented below route through this. |
+| `call(action, **kwargs)` | Invoke any action by name. The methods documented below route through this; it also accepts the action and argument names exactly as the browser declares them, for example `page.call("tree", maxDepth=1)`. |
 
 Sessions are context managers too: `with browser.new_session() as page:` closes the session on exit. Closing the browser ends every session anyway.
 
 ## Calling an action
 
-Every browser action is a method on `Session`/`AsyncSession`, keyword-only. The original action name (`waitForSelector`) and a snake_case alias (`wait_for_selector`) both resolve to the same method: call whichever reads better in your code.
-
-<Callout type="warning">
-  Only the method name gets a snake_case alias; its keyword arguments keep their original names. `wait_for_selector(selector=..., timeout=...)` has no case change, but `click(selector=..., backendNodeId=...)`, `screenshot(fullPage=...)`, and `tree(maxDepth=...)` all keep a camelCase keyword even though the method itself is snake_case.
-</Callout>
+Every browser action is a method on `Session`/`AsyncSession`, keyword-only, with the action and its arguments in snake_case: the `waitForSelector` action is `wait_for_selector`, and its `backendNodeId` argument is `backend_node_id`. The methods are generated from the bundled browser's action schemas, so the signatures and docstrings your IDE shows come straight from the binary. The generated reference for the latest release is published at [lightpanda.io/lightpanda-python](https://lightpanda.io/lightpanda-python/).
 
 A failed action raises `ToolError`.
 
-In the Arguments column below, `?` marks an optional keyword argument, and `selector` / `backendNodeId` marks a pair where one of the two is required. Prefer `selector` for reproducibility; it also wins when you pass both. `backendNodeId` values come from a prior `tree`, `links`, or `find_element` call. In the Returns column, `JSON` is a parsed Python `dict` or `list`, `text` is a plain string.
+In the Arguments column below, `?` marks an optional keyword argument, and `selector` / `backend_node_id` marks a pair where one of the two is required. Prefer `selector` for reproducibility; it also wins when you pass both. `backend_node_id` takes the `backendNodeId` values returned by a prior `tree`, `links`, or `find_element` call. In the Returns column, `JSON` is a parsed Python `dict` or `list`, `text` is a plain string.
 
 ### Navigation and search
 
@@ -78,7 +73,7 @@ These methods bring a page into the browser:
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `goto` | `url`, `timeout?`, `waitUntil?` | text | Navigate to a URL and load the page in memory so it can be reused later for info extraction. `waitUntil` accepts the same states as `wait_for_state` and defaults to `load`. On the 0.4.0 wheel, `waitUntil` isn't yet a keyword; reach it with `page.call("goto", url=..., waitUntil=...)` until the next release. |
+| `goto` | `url`, `timeout?`, `wait_until?` | text | Navigate to a URL and load the page in memory so it can be reused later for info extraction. `wait_until` accepts the same states as `wait_for_state` and defaults to `load`. |
 | `search` | `query`, `timeout?` | text | Run a web search and return results as markdown: a numbered list of `{title, url, snippet}`. The browser does not navigate; to open a result, call `goto` with its URL. |
 
 ### Reading the page
@@ -87,16 +82,16 @@ These methods read the loaded page without modifying it:
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `markdown` | `selector?`, `backendNodeId?`, `maxBytes?`, `url?`, `timeout?` | text | Render the page, or a subtree, as markdown. Scope with `selector` or `backendNodeId` to read just the relevant region; use `maxBytes` to cap long pages. |
-| `html` | `selector?`, `backendNodeId?`, `maxBytes?`, `strip?`, `url?`, `timeout?` | text | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. Use `maxBytes` to cap long pages. `strip` is an object of element groups to omit: `js` (script, noscript, script preloads), `css` (style, stylesheet links), `ui` (css plus img, picture, video, audio, svg, canvas, iframe) and `invisible` (elements set to display:none). `{"js": True, "css": True}` keeps a page dump small. On the 0.4.0 wheel, `maxBytes` and `strip` aren't yet keywords; reach them with `page.call("html", maxBytes=..., strip=...)` until the next release. |
-| `screenshot` | `path?`, `selector?`, `backendNodeId?`, `fullPage?`, `url?`, `timeout?` | text or bytes | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. In the 0.4.0 wheel, the Python SDK doesn't request an inline image, so without `path` you get a plain size summary, not the image itself; always pass `path` for now. A later release is expected to return the image as `bytes` when `path` is omitted. |
-| `tree` | `url?`, `timeout?`, `backendNodeId?`, `maxDepth?` | text | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
-| `links` | `limit?`, `url?`, `timeout?` | JSON | Extract all links as `text` (visible anchor text, falling back to aria-label/title/image alt), `href` (resolved URL), and `backendNodeId` (pass to `node_details`). One entry per href; hidden links are omitted. `limit` returns at most that many links, in document order. On the 0.4.0 wheel, `limit` isn't yet a keyword; reach it with `page.call("links", limit=...)` until the next release. |
-| `node_details` (`nodeDetails`) | `backendNodeId` | JSON | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
-| `find_element` (`findElement`) | `role?`, `name?` | JSON | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
-| `interactive_elements` (`interactiveElements`) | `url?`, `timeout?` | JSON | Every interactive element on the page. |
-| `structured_data` (`structuredData`) | `url?`, `timeout?` | JSON | Structured data on the page, such as JSON-LD or OpenGraph tags. |
-| `detect_forms` (`detectForms`) | `url?`, `timeout?` | JSON | Forms on the page: fields, types, and required status. |
+| `markdown` | `selector?`, `backend_node_id?`, `max_bytes?`, `url?`, `timeout?` | text | Render the page, or a subtree, as markdown. Scope with `selector` or `backend_node_id` to read just the relevant region; use `max_bytes` to cap long pages. |
+| `html` | `selector?`, `backend_node_id?`, `max_bytes?`, `strip?`, `url?`, `timeout?` | text | Raw HTML for the document, or a single node's outerHTML when scoped. Verbose; use only when you need attributes that markdown discards. Use `max_bytes` to cap long pages. `strip` is an object of element groups to omit: `js` (script, noscript, script preloads), `css` (style, stylesheet links), `ui` (css plus img, picture, video, audio, svg, canvas, iframe) and `invisible` (elements set to display:none). `{"js": True, "css": True}` keeps a page dump small. |
+| `screenshot` | `path?`, `selector?`, `backend_node_id?`, `full_page?`, `url?`, `timeout?` | text or bytes | Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate rendering (no images, fonts, or CSS colors). `path` must be a relative path. Without `path`, the PNG is returned as `bytes`. |
+| `tree` | `url?`, `timeout?`, `backend_node_id?`, `max_depth?` | text | Simplified semantic DOM tree: role, name, value, and `backendNodeId` per node. |
+| `links` | `limit?`, `url?`, `timeout?` | JSON | Extract all links as `text` (visible anchor text, falling back to aria-label/title/image alt), `href` (resolved URL), and `backendNodeId` (pass to `node_details`). One entry per href; hidden links are omitted. `limit` returns at most that many links, in document order. |
+| `node_details` | `backend_node_id` | JSON | Tag, role, name, value, and other state for a node, plus a ready-to-use CSS `selector` that resolves to it. The way to turn a `backendNodeId` into a selector. |
+| `find_element` | `role?`, `name?` | JSON | Find interactive elements by role and/or accessible name, with their `backendNodeId`. |
+| `interactive_elements` | `url?`, `timeout?` | JSON | Every interactive element on the page. |
+| `structured_data` | `url?`, `timeout?` | JSON | Structured data on the page, such as JSON-LD or OpenGraph tags. |
+| `detect_forms` | `url?`, `timeout?` | JSON | Forms on the page: fields, types, and required status. |
 
 ### Data extraction and scripting
 
@@ -125,13 +120,13 @@ These methods dispatch real DOM events on the page:
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `click` | `selector` / `backendNodeId` | text | Click an interactive element. |
-| `fill` | `selector` / `backendNodeId`, `value` | text | Fill text into an input element. |
-| `scroll` | `backendNodeId?`, `x?`, `y?` | text | Scroll the page, or a specific element if `backendNodeId` is given. |
-| `hover` | `selector` / `backendNodeId` | text | Hover over an element, triggering `mouseover` and `mouseenter`. |
-| `press` | `key`, `selector?`, `backendNodeId?` | text | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
-| `select_option` (`selectOption`) | `selector` / `backendNodeId`, `value` | text | Select an option in a `<select>` element by its value. |
-| `set_checked` (`setChecked`) | `selector` / `backendNodeId`, `checked` | text | Check (`True`) or uncheck (`False`) a checkbox or radio button. Dispatches input, change, and click events. |
+| `click` | `selector` / `backend_node_id` | text | Click an interactive element. |
+| `fill` | `selector` / `backend_node_id`, `value` | text | Fill text into an input element. |
+| `scroll` | `backend_node_id?`, `x?`, `y?` | text | Scroll the page, or a specific element if `backend_node_id` is given. |
+| `hover` | `selector` / `backend_node_id` | text | Hover over an element, triggering `mouseover` and `mouseenter`. |
+| `press` | `key`, `selector?`, `backend_node_id?` | text | Press a keyboard key, dispatching `keydown` and `keyup`. Targets the document if no element is given. |
+| `select_option` | `selector` / `backend_node_id`, `value` | text | Select an option in a `<select>` element by its value. |
+| `set_checked` | `selector` / `backend_node_id`, `checked` | text | Check (`True`) or uncheck (`False`) a checkbox or radio button. Dispatches input, change, and click events. |
 
 ### Waiting
 
@@ -139,18 +134,18 @@ These methods block until the page reaches a condition:
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `wait_for_selector` (`waitForSelector`) | `selector`, `timeout?` | text | Wait for an element matching a CSS selector to appear, and return its `backendNodeId`. |
-| `wait_for_script` (`waitForScript`) | `script`, `timeout?` | text | Wait until a JavaScript expression returns truthy, re-evaluated on every tick. |
-| `wait_for_state` (`waitForState`) | `state`, `timeout?` | text | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
+| `wait_for_selector` | `selector`, `timeout?` | text | Wait for an element matching a CSS selector to appear, and return its `backendNodeId`. |
+| `wait_for_script` | `script`, `timeout?` | text | Wait until a JavaScript expression returns truthy, re-evaluated on every tick. |
+| `wait_for_state` | `state`, `timeout?` | text | Wait for the page to reach a load state (`load`, `domcontentloaded`, `networkalmostidle`, `networkidle`, or `done`), with no navigation. |
 
 ### State and debugging
 
 | Method | Arguments | Returns | Description |
 |---|---|---|---|
-| `get_url` (`getUrl`) | none | text | The URL currently loaded in the session. |
-| `get_cookies` (`getCookies`) | `url?`, `all?` | text | Cookies stored in the browser. Defaults to the current page's host; pass `url` for another host or `all=True` for every cookie. |
-| `get_env` (`getEnv`) | `name?` | text | With `name`, read one `LP_*` environment variable. Without it, list the `LP_*` names that are set. |
-| `console_logs` (`consoleLogs`) | none | text | Buffered `console.log`/`warn`/`error` messages since the last call, which then clears the buffer. |
+| `get_url` | none | text | The URL currently loaded in the session. |
+| `get_cookies` | `url?`, `all?` | text | Cookies stored in the browser. Defaults to the current page's host; pass `url` for another host or `all=True` for every cookie. |
+| `get_env` | `name?` | text | With `name`, read one `LP_*` environment variable. Without it, list the `LP_*` names that are set. |
+| `console_logs` | none | text | Buffered `console.log`/`warn`/`error` messages since the last call, which then clears the buffer. |
 
 ## Script replay
 


### PR DESCRIPTION
Follows lightpanda-io/lightpanda-python#3, which drops the camelCase aliases from the Python package and converts the action arguments to snake_case (`wait_for_selector`, `backend_node_id`, `max_depth`, ...), and publishes the pdoc reference to GitHub Pages at https://lightpanda.io/docs/python/ (see #92 for the workflow that publishes it).

- Reference: the "Calling an action" section now states the snake_case rule and links the generated reference; `call` is documented as the escape hatch that takes the browser's own names. The method column loses its camelCase aliases and every Arguments column is renamed. Result keys such as `backendNodeId` in `tree`/`links`/`node_details` output stay camelCase, since that is what the browser returns.
- Guide: the callout and the pointer to the reference updated accordingly.
- Dropped the four "on the 0.4.0 wheel" caveats: the next wheel exposes `wait_until`, `max_bytes`, `strip` and `limit` as keywords and returns an inline screenshot as `bytes`.

This describes the next Python release, so it should be merged alongside it rather than before.