### PR TITLE
Drop the links to the generated Python API reference

### DIFF
--- a/src/content/guides/use-python.mdx
+++ b/src/content/guides/use-python.mdx
@@ -164,7 +164,7 @@ asyncio.run(main())
   Every browser action is a `Session` method, typed and documented in your IDE, with the action and its arguments in snake_case (`wait_for_selector`, `backend_node_id`).
 </Callout>
 
-Find every method's arguments in the [Python SDK reference](/reference/python), or browse the generated API reference at [lightpanda.io/lightpanda-python](https://lightpanda.io/lightpanda-python/).
+Find every method's arguments in the [Python SDK reference](/reference/python).
 
 ## Replay a saved script
 

--- a/src/content/reference/python.mdx
+++ b/src/content/reference/python.mdx
@@ -61,7 +61,7 @@ Sessions are context managers too: `with browser.new_session() as page:` closes 
 
 ## Calling an action
 
-Every browser action is a method on `Session`/`AsyncSession`, keyword-only, with the action and its arguments in snake_case: the `waitForSelector` action is `wait_for_selector`, and its `backendNodeId` argument is `backend_node_id`. The methods are generated from the bundled browser's action schemas, so the signatures and docstrings your IDE shows come straight from the binary. The generated reference for the latest release is published at [lightpanda.io/lightpanda-python](https://lightpanda.io/lightpanda-python/).
+Every browser action is a method on `Session`/`AsyncSession`, keyword-only, with the action and its arguments in snake_case: the `waitForSelector` action is `wait_for_selector`, and its `backendNodeId` argument is `backend_node_id`. The methods are generated from the bundled browser's action schemas, so the signatures and docstrings your IDE shows come straight from the binary.
 
 A failed action raises `ToolError`.
 


### PR DESCRIPTION
The pdoc-generated Python reference is not being published for now, so the Python guide and SDK reference no longer link to lightpanda.io/lightpanda-python.

Replaces #92.