### PR TITLE
Sync --adblock-lists help text with the request-engine rewrite

### DIFF
--- a/src/content/reference/cli/common-options.mdx
+++ b/src/content/reference/cli/common-options.mdx
@@ -13,7 +13,8 @@ Every Lightpanda command ([fetch](/reference/cli/fetch), [serve](/reference/cli/
 common options:
   --adblock-lists <LIST>
           EasyList-syntax filter files to load. Can be passed multiple times.
-          Requests to a hostname blocked by any list are failed before they leave.
+          Requests a list blocks are failed before they leave; the URL,
+          resource type, party and $domain= of each one decide.
           e.g. --adblock-lists easylist.txt --adblock-lists easyprivacy.txt
   --block-cidrs <CIDR>
           Additional CIDR ranges to block. Can be passed multiple times.


### PR DESCRIPTION
- `--adblock-lists` help text was still describing the original hostname-trie blocker; lightpanda-io/browser#3245 replaced it with a full network-filter engine that matches on URL, resource type, party and `$domain=`, not just hostname.
- Updated `common-options.mdx` to match the current `help.zon` wording exactly.