### PR TITLE
Document --locale and --timezone common CLI options

### DIFF
--- a/src/content/reference/cli/common-options.mdx
+++ b/src/content/reference/cli/common-options.mdx
@@ -119,6 +119,10 @@ common options:
   --insecure-disable-tls-host-verification
           Disables host verification on all HTTP requests.
           Only set this if you understand and accept the risk.
+  --locale <TAG>
+          BCP 47 language tag driving navigator.language, the
+          Accept-Language header and the default locale of Intl and
+          toLocaleString. Defaults to en-US.
   --log-filter <SCOPE>
           Filter logs per scope, applied first-to-last. Can be passed multiple times.
           "-X" (or bare "X") filters out a scope, "+X" filters it in, and
@@ -148,6 +152,9 @@ common options:
   --storage-sqlite-path <PATH>
           Path to the SQLite database file for persistent storage.
           Use ":memory:" for in-memory storage.
+  --timezone <IANA>
+          Time zone used by Date and Intl, e.g. Europe/Paris or UTC.
+          Defaults to the host time zone.
   --user-agent <STRING>
           Override the User-Agent header entirely. Must not impersonate other
           browsers; any value containing "Mozilla" is forbidden. The browser


### PR DESCRIPTION
- Adds `--locale <TAG>` and `--timezone <IANA>` to the common options reference, verbatim from `help.zon` (browser PR lightpanda-io/browser#3466, merged as 33ddbdf0f).
- Both are shared options (fetch/serve/mcp/agent/run) and slot in alphabetically, matching `help.zon`'s order.