### PR TITLE
Sync --strip-mode docs with the new clutter and shell modes

### DIFF
--- a/src/content/guides/markdown-axtree.mdx
+++ b/src/content/guides/markdown-axtree.mdx
@@ -96,13 +96,7 @@ lightpanda fetch --dump html --strip-mode js,css https://example.com
 lightpanda fetch --dump html --strip-mode clutter https://example.com
 ```
 
-| Value | Tags removed |
-|---|---|
-| `js` | `script`, `link[as=script]`, `link[rel=preload]` |
-| `css` | `style`, `link[rel=stylesheet]` |
-| `ui` | `img`, `picture`, `video`, `svg`, `style`, `link[rel=stylesheet]` |
-| `shell` | Page chrome by markup: `nav`, `aside`, `dialog`, page-level header and footer |
-| `clutter` | Heuristic to keep only the main content, in the manner of reader modes |
+Find all options in the [fetch command reference](/reference/cli/fetch#options).
 
 ### Semantic tree output
 

--- a/src/content/guides/markdown-axtree.mdx
+++ b/src/content/guides/markdown-axtree.mdx
@@ -92,8 +92,8 @@ Removes groups of tags from the output. Values can be combined with commas:
 # Remove JavaScript and CSS from output
 lightpanda fetch --dump html --strip-mode js,css https://example.com
 
-# Remove all UI, scripts and styles
-lightpanda fetch --dump html --strip-mode full https://example.com
+# Keep only the main content, reader-mode style
+lightpanda fetch --dump html --strip-mode clutter https://example.com
 ```
 
 | Value | Tags removed |
@@ -101,7 +101,8 @@ lightpanda fetch --dump html --strip-mode full https://example.com
 | `js` | `script`, `link[as=script]`, `link[rel=preload]` |
 | `css` | `style`, `link[rel=stylesheet]` |
 | `ui` | `img`, `picture`, `video`, `svg`, `style`, `link[rel=stylesheet]` |
-| `full` | Combines `js` + `ui` + `css` |
+| `shell` | Page chrome by markup: `nav`, `aside`, `dialog`, page-level header and footer |
+| `clutter` | Heuristic to keep only the main content, in the manner of reader modes |
 
 ### Semantic tree output
 

--- a/src/content/reference/cli/fetch.mdx
+++ b/src/content/reference/cli/fetch.mdx
@@ -56,15 +56,18 @@ options:
           Defaults to false.
   --strip-mode <STRIP>
           Tag group to remove from dump. Can be passed multiple times.
-          In markdown only 'ui' changes the output: scripts, styles and
-          hidden elements are never rendered.
-          Defaults to no-strip.
+          Defaults to stripping nothing.
           Allowed values:
-              js        Script and link[as=script, rel=preload].
-              ui        Includes img, picture, video, CSS and SVG.
+              clutter   Heuristic to keep only the main content, in the
+                        manner of reader modes. May fallback to `shell`
+                        (which may itself fall back to a full dump).
               css       Includes style and link[rel=stylesheet].
+              js        Script and link[as=script, rel=preload].
               invisible Best-effort (e.g. display:none) hidden elements
-              full      Strip everything.
+              shell     Page chrome by markup: nav, aside, dialog,
+                        page-level header and footer. Full dump when
+                        `shell` would remove most of the text.
+              ui        Includes img, picture, video, CSS and SVG.
   --terminate-ms <INT>
           Hard deadline in milliseconds. After this time elapses, JavaScript
           execution is forcibly terminated (e.g. for pages with endless scripts).


### PR DESCRIPTION
- Updates `--strip-mode`'s allowed values in the CLI reference, verbatim from `help.zon` (browser PR lightpanda-io/browser#3428, merged as 241083a8): adds `clutter` (readability-style main-content extraction) and `shell` (page chrome by markup), drops `full` (removed from the source's `Strip` enum, no longer a valid value).
- Fixes the `guides/markdown-axtree.mdx` example and table that used `--strip-mode full`, which would now error since the value no longer exists.